### PR TITLE
ReservationManagement.jsx 일부 구현 완료

### DIFF
--- a/refacbus_admin/package-lock.json
+++ b/refacbus_admin/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^19.1.0",
         "react-calendar": "^6.0.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3"
+        "react-router-dom": "^7.6.3",
+        "recharts": "^3.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1400,6 +1401,31 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -1666,6 +1692,16 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1706,6 +1742,60 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1753,6 +1843,11 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.6.0",
@@ -2210,6 +2305,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -2230,6 +2435,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2283,6 +2493,11 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.7",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
+      "integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw=="
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -2511,6 +2726,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2826,6 +3046,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2848,6 +3077,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -3676,6 +3913,28 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
       "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3768,6 +4027,50 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.0.tgz",
+      "integrity": "sha512-NqAqQcGBmLrfDs2mHX/bz8jJCQtG2FeXfE0GqpZmIuXIjkpIwj8sd9ad0WyvKiBKPd8ZgNG0hL85c8sFDwascw==",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4153,6 +4456,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -4238,11 +4546,40 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "7.0.0",

--- a/refacbus_admin/package.json
+++ b/refacbus_admin/package.json
@@ -18,7 +18,8 @@
     "react": "^19.1.0",
     "react-calendar": "^6.0.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "recharts": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/refacbus_admin/src/pages/DashBoard.jsx
+++ b/refacbus_admin/src/pages/DashBoard.jsx
@@ -16,7 +16,6 @@ const Dashboard = () => {
     onValue(noticeRef, (snapshot) => {
       const data = snapshot.val();
       if (data) {
-        // 'isPinned'가 true인 것만 필터링
         const pinned = Object.values(data).filter(n => n.isPinned === true);
         setNotices(pinned);
       }

--- a/refacbus_admin/src/pages/DriverManagement.jsx
+++ b/refacbus_admin/src/pages/DriverManagement.jsx
@@ -16,8 +16,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import AddIcon from "@mui/icons-material/Add";
 import dayjs from "dayjs"; 
-import { getColorByRoute } from "../utils/colorUnits"; // 경로는 너 프로젝트 구조에 맞게!
-
+import { getColorByRoute } from "../utils/colorUnits"; 
 
 const TabPanel = ({ children, value, index }) => {
   return (
@@ -218,12 +217,10 @@ const DriverManagement = () => {
         updates.isBanned = true;
       }
   
-      // 상태 관련 업데이트 (memo 제외)
       if (Object.keys(updates).length > 0) {
         await update(userRef, updates);
       }
   
-      // 로컬 상태 반영
       setAllUsers((prev) =>
         prev.map((u) =>
           u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
@@ -243,7 +240,6 @@ const DriverManagement = () => {
       const handleUnban = async (uid) => {
       await update(ref(realtimeDb, `drivers/${uid}`), { isBanned: false });
   
-      // 👉 상태 업데이트
       setAllUsers((prev) =>
         prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
       );
@@ -287,7 +283,7 @@ const DriverManagement = () => {
   
     const handleOpenReset = (user) => {
       setTargetUser(user);
-      setResetEmail(user.email); // 👉 디폴트 이메일
+      setResetEmail(user.email); 
       setIsResetOpen(true);
     };
   
@@ -319,7 +315,6 @@ const DriverManagement = () => {
               endTime: item.endTime,
             }))
             .sort((a, b) => {
-              // 최신 날짜 + 시간 기준 정렬
               const aDate = new Date(`${a.date}T${a.time}`);
               const bDate = new Date(`${b.date}T${b.time}`);
               return bDate - aDate;
@@ -387,8 +382,7 @@ const DriverManagement = () => {
           if (!selected) return;
 
           setSelectedRouteId(selected.id);
-          setSelectedRouteDetails(selected); // 🔥 전체 노선 정보 저장
-
+          setSelectedRouteDetails(selected); 
           try {
             const snapshot = await get(ref(realtimeDb, `routes/${selected.id}/times`));
             if (snapshot.exists()) {
@@ -414,7 +408,7 @@ const DriverManagement = () => {
       const newSchedule = {
         route: selectedRoute,
         time: selectedTime,
-        duration: duration, // 🔥 필수
+        duration: duration, 
         days: selectedDays,
         createdAt: new Date().toISOString()
       };
@@ -434,19 +428,17 @@ const DriverManagement = () => {
           );
           await set(targetRef, newSchedule);
         } else {
-          // ✅ 추가 모드일 경우 새로 추가
           const newRef = push(scheduleRef);
           await set(newRef, newSchedule);
         }
 
-        // 저장 후 상태 초기화
         setIsAddDialogOpen(false);
         setSelectedRoute('');
         setSelectedTime('');
         setSelectedDays([]);
         setSelectedCellTime('');
         setDuration('');
-        setIsEditing(false); // ✅ 수정 모드 해제
+        setIsEditing(false); 
         setEditingScheduleKey(null);
 
         fetchDriverSchedule(currentTargetUser.uid);
@@ -468,11 +460,10 @@ const DriverManagement = () => {
 
     setDriverSchedules((prev) => ({ ...prev, [uid]: data }));
 
-    // 🧩 기사별 색 계산도 따로 저장
     const newColored = analyzeSchedule(data);
     console.log("🎨 색칠할 셀", newColored);
     setColoredSchedule((prev) => ({
-       ...prev, [uid]: newColored })); // ✅
+       ...prev, [uid]: newColored })); 
   } else {
     console.log("❌ 해당 유저 스케줄 없음:", uid);
   }
@@ -489,13 +480,10 @@ const DriverManagement = () => {
         const { days, time, duration } = item;
         if (!days || !time || !duration) return;
 
-        // 🕐 시간 파싱 (예: "08:30")
         const [hourStr, minuteStr] = time.split(":");
         const hour = parseInt(hourStr, 10);
         const minute = parseInt(minuteStr, 10);
 
-        // 🎯 timeSlots에서 해당 시간이 포함될 "베이스 index" 찾기
-        // 예: 08:30 → 08:00 셀에 포함
         let startIndex = -1;
 
         for (let i = 0; i < timeSlots.length; i++) {
@@ -511,11 +499,9 @@ const DriverManagement = () => {
           }
         }
 
-        if (startIndex === -1) return; // 못 찾은 경우
-
-        // 📌 요일별 셀 색칠
+        if (startIndex === -1) return; 
         days.forEach((day) => {
-          const col = getDayIndex(day); // 월: 0, 화:1, ...
+          const col = getDayIndex(day);
           for (let i = 0; i < duration; i++) {
             const row = startIndex + i;
             const cellKey = `${col}-${row}`;
@@ -561,7 +547,6 @@ const DriverManagement = () => {
           
         >
           <Tab label="기사별 운행 이력" />
-          <Tab label="탑승자 수 통계" />
           <Tab label="기사 계정 관리" />
         </Tabs>
       </Box>
@@ -667,8 +652,7 @@ const DriverManagement = () => {
                                             const isColored = coloredSchedule[user.uid]?.includes(cellKey);
                                             let routeText = '';
                                             let isStartCell = false;
-                                            let bgColor = "inherit"; // 배경색 기본값
-
+                                            let bgColor = "inherit"; 
                                             const scheduleData = driverSchedules[user.uid];
                                             if (scheduleData) {
                                               Object.values(scheduleData).forEach(({ days, time, duration, route }) => {
@@ -687,7 +671,6 @@ const DriverManagement = () => {
                                                     routeText = `${route}\n(${time})`;
                                                     isStartCell = true;
                                                   }
-                                                  // 🌈 여기에 색상 적용!
                                                   bgColor = getColorByRoute(route);
                                                 }
                                               });
@@ -712,9 +695,8 @@ const DriverManagement = () => {
                                                 userSelect: "none"
                                               }}
                                               onClick={() => {
-                                                if (!isColored) return; // 색 없는 셀 클릭 방지
+                                                if (!isColored) return; 
 
-                                                // 🔥 셀 클릭 시, 스케줄 전체 찾아서 수정
                                                 const matchedSchedule = Object.values(driverSchedules[user.uid]).find(
                                                   ({ days, time, duration }) => {
                                                     const startIdx = timeSlots.findIndex((slot) => {
@@ -738,7 +720,7 @@ const DriverManagement = () => {
                                                     value.duration === matchedSchedule.duration &&
                                                     value.route === matchedSchedule.route &&
                                                     JSON.stringify(value.days) === JSON.stringify(matchedSchedule.days)
-                                                )?.[0]; // 🔥 Firebase의 키
+                                                )?.[0]; 
 
                                                 fetchPinnedRoutes(user.uid).then(() => {
                                                   setSelectedDays(matchedSchedule.days);
@@ -746,14 +728,14 @@ const DriverManagement = () => {
                                                   setDuration(matchedSchedule.duration);
                                                   setSelectedRoute(matchedSchedule.route);
                                                   setCurrentTargetUser(user);
-                                                  setIsEditing(true); // ✅ 수정 모드 켜기
-                                                  setEditingScheduleKey(scheduleKey); // ✅ 수정할 항목의 Firebase 키 저장
+                                                  setIsEditing(true); 
+                                                  setEditingScheduleKey(scheduleKey);
                                                   handleRouteSelect({
                                                     target: { value: matchedSchedule.route },
                                                   });
                                                   setIsAddDialogOpen(true);
-                                                }); // ✨ 기존 Dialog 재활용 가능!
-                                                }
+                                                }); 
+                                              }
                                               }}
                                             >
                                               {isStartCell && (
@@ -783,7 +765,7 @@ const DriverManagement = () => {
                 <Dialog open={isAddDialogOpen} onClose={handleCloseAddDialog} 
                   PaperProps={{
                     sx: {
-                      width: "600px", // 원하는 너비(px, %, vw 등)
+                      width: "600px", 
                     },
                   }}>
                   <DialogTitle>스케줄 추가</DialogTitle>
@@ -912,8 +894,7 @@ const DriverManagement = () => {
                 
             </Box>
         </TabPanel>
-        <TabPanel value={tabIndex} index={1}>탑승자 수 통계</TabPanel>
-        <TabPanel value={tabIndex} index={2}>
+        <TabPanel value={tabIndex} index={1}>
           <Box sx={{ width: '100%', height: '100%', backgroundColor: '#fff',  }}>
                 <TextField
                   label="이름으로 검색"
@@ -1054,8 +1035,7 @@ const DriverManagement = () => {
                         email: editedEmail,
                         name: editedName,
                       });
-          
-                      // 🔄 로컬 상태도 갱신
+        
                       setAllUsers((prev) =>
                         prev.map((u) => u.uid === editingUser.uid ? { ...u, email: editedEmail, name: editedName } : u)
                       );

--- a/refacbus_admin/src/pages/Home.jsx
+++ b/refacbus_admin/src/pages/Home.jsx
@@ -26,7 +26,6 @@ function Home() {
         return <DriverManagement/> ;
       case 'managermanage':
         return <ManagerManagement/> ;
-      // 필요한 경우 driver 등 다른 것도 추가
       default:
         return <div>기능을 선택해주세요</div>;
     }

--- a/refacbus_admin/src/pages/Login.jsx
+++ b/refacbus_admin/src/pages/Login.jsx
@@ -1,4 +1,3 @@
-// src/pages/Login.jsx
 
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
@@ -17,12 +16,10 @@ export default function Login() {
     const togglePasswordVisibility = () => {
     setShowPassword(true);
   
-    // 이전 타이머 제거
     if (passwordTimeoutRef.current) {
       clearTimeout(passwordTimeoutRef.current);
     }
   
-    // 1초 뒤에 다시 가리기
     passwordTimeoutRef.current = setTimeout(() => {
       setShowPassword(false);
     }, 1000);
@@ -82,7 +79,7 @@ export default function Login() {
 
   const handleKeyDown = (e) => {
   if (e.key === 'Enter') {
-    handleLogin(); // 엔터 누르면 로그인 함수 실행
+    handleLogin(); 
   }
 };
 

--- a/refacbus_admin/src/pages/ManagerManagement.jsx
+++ b/refacbus_admin/src/pages/ManagerManagement.jsx
@@ -57,7 +57,6 @@ const ManagerManagement = () => {
     const newRef = push(ref(realtimeDb, 'notices'));
     set(newRef, newNotice);
 
-    // 초기화
     setOpen(false);
     setTitle('');
     setUrl('');
@@ -73,7 +72,6 @@ const ManagerManagement = () => {
           id,
           ...item
         }));
-        // 고정 공지 먼저 정렬
         list.sort((a, b) => b.isPinned - a.isPinned);
         setNotices(list);
       } else {

--- a/refacbus_admin/src/pages/PlaceTimeManagement.jsx
+++ b/refacbus_admin/src/pages/PlaceTimeManagement.jsx
@@ -50,7 +50,6 @@ const PlaceTimeManagement = () => {
       const newRef = push(ref(realtimeDb, 'routes'));
       set(newRef, newRoute);
   
-      // 초기화
       setOpen(false);
       setRoute('');
       setIsPinned(false);
@@ -65,7 +64,6 @@ const PlaceTimeManagement = () => {
             id,
             ...item
           }));
-          // 고정 공지 먼저 정렬
           list.sort((a, b) => b.isPinned - a.isPinned);
           setRouteList(list);
         } else {
@@ -123,7 +121,7 @@ const PlaceTimeManagement = () => {
       const handleSubmitMemo = async () => {
         if (!selectedRoute || !routeText.trim()) return;
 
-        const targetKey = tabIndex === 1 ? "times" : "stops"; // ✅ 시간/정류장 구분
+        const targetKey = tabIndex === 1 ? "times" : "stops";
         const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/${targetKey}`);
         await push(dataRef, routeText.trim());
 
@@ -141,7 +139,6 @@ const PlaceTimeManagement = () => {
           )
         );
 
-        // 초기화
         setIsRouteOpen(false);
         setRouteText('');
         setSelectedRoute(null);
@@ -151,7 +148,7 @@ const PlaceTimeManagement = () => {
       setOpenRouteId(prev => (prev === uid ? null : uid));
       };
 
-      const [selectedTimeInfo, setSelectedTimeInfo] = useState(null); // { routeId, timeId, value }
+      const [selectedTimeInfo, setSelectedTimeInfo] = useState(null); 
       const [openTimeDialog, setOpenTimeDialog] = useState(false);
       const [editTimeText, setEditTimeText] = useState('');
 
@@ -168,7 +165,7 @@ const PlaceTimeManagement = () => {
         setIsStopDialogOpen(true); 
       };
 
-      const [selectedRouteInfo, setSelectedRouteInfo] = useState(null); // { id, name }
+      const [selectedRouteInfo, setSelectedRouteInfo] = useState(null); 
       const [editRouteText, setEditRouteText] = useState('');
       const [openRouteDialog, setOpenRouteDialog] = useState(false);
 
@@ -192,10 +189,10 @@ const PlaceTimeManagement = () => {
           onChange={handleTabChange}
           textColor="primary"
           indicatorColor="primary"
-          variant="standard" // ← 요거!
-          centered             // ← 요거!
+          variant="standard"
+          centered             
           sx={{
-            minWidth: 'fit-content',  // ← 너무 좁게 붙는 거 방지
+            minWidth: 'fit-content',  
           }}
         >
           <Tab label="노선 추가 / 삭제" />
@@ -298,7 +295,6 @@ const PlaceTimeManagement = () => {
                             color="error"
                             onClick={async () => {
                               if (!selectedRouteInfo) return;
-                              // ✅ 삭제 로직 (Firebase에서 삭제, localState에서 제거)
                               await remove(ref(realtimeDb, `routes/${selectedRouteInfo.id}`));
                               setRouteList((prev) => prev.filter((r) => r.id !== selectedRouteInfo.id));
                               setOpenRouteDialog(false);
@@ -310,7 +306,6 @@ const PlaceTimeManagement = () => {
                             color="primary"
                             onClick={async () => {
                               if (!selectedRouteInfo) return;
-                              // ✅ 수정 로직
                               await set(ref(realtimeDb, `routes/${selectedRouteInfo.id}/name`), editRouteText);
                               const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRouteInfo.id}`));
                               const updatedData = updatedSnapshot.val();
@@ -468,7 +463,7 @@ const PlaceTimeManagement = () => {
                   onClick={async () => {
                     if (!selectedTimeInfo) return;
                     const { routeId, timeId } = selectedTimeInfo;
-                    await set(ref(realtimeDb, `routes/${routeId}/times/${timeId}`), editTimeText); // 수정
+                    await set(ref(realtimeDb, `routes/${routeId}/times/${timeId}`), editTimeText); 
                     const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
                     const updatedData = updatedSnapshot.val();
                    

--- a/refacbus_admin/src/pages/Register.jsx
+++ b/refacbus_admin/src/pages/Register.jsx
@@ -1,4 +1,4 @@
-// src/pages/Register.jsx
+
 import { useState } from "react";
 import { firestoreDb, realtimeDb, app } from "../firebase";
 import { doc, getDoc } from "firebase/firestore";
@@ -54,7 +54,6 @@ export default function Register() {
     
 
     try {
-      // 관리자 코드 확인 (Firestore)
       const docRef = doc(firestoreDb, "admin_code", "admin_key");
       const docSnap = await getDoc(docRef);
 
@@ -69,14 +68,11 @@ export default function Register() {
         return;
       }
 
-      // ✅ 이메일 형식으로 변환
       const email = `${id}@example.com`;
 
-      // Firebase Auth 회원가입
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
       const uid = userCredential.user.uid;
 
-      // Realtime Database에 관리자 정보 저장
       await set(ref(realtimeDb, `admin/${uid}`), {
         id,
         name,

--- a/refacbus_admin/src/pages/ReservationManagement.jsx
+++ b/refacbus_admin/src/pages/ReservationManagement.jsx
@@ -1,7 +1,12 @@
-import React, { useState } from 'react';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import React, { useState, useEffect } from 'react';
+import {
+  TextField, Box, Table, TableContainer, TableHead, TableCell, TableRow, TableBody,
+  Menu, MenuItem, Dialog, DialogTitle, DialogContent, DialogActions, Select,
+  Checkbox, FormControlLabel, Button, Typography, Paper, Tab, Tabs, FormControl, InputLabel
+} from '@mui/material';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip} from 'recharts';
+import dayjs from 'dayjs';
+import { getDatabase, ref, get, child } from 'firebase/database';
 
 const TabPanel = ({ children, value, index }) => {
   return (
@@ -22,6 +27,182 @@ const ReservationManagement = () => {
     setTabIndex(newValue);
   };
 
+  const [year, setYear] = useState('');
+  const [month, setMonth] = useState('');
+  const [day, setDay] = useState('');
+  const [searchName, setSearchName] = useState('');
+  const [reservationList, setReservationList] = useState([]); // 조회된 전체 예약 목록
+  const [filteredData, setFilteredData] = useState([]); // 검색어 포함 필터링된 목록
+
+  const handleYearChange = (event) => {
+    setYear(event.target.value);
+  };
+
+  const handleMonthChange = (event) => {
+    setMonth(event.target.value);
+  };
+
+  const handleDayChange = (event) => {
+    setDay(event.target.value);
+  };
+
+
+  const handleSearch = async () => {
+    if (!year || !month || !day) {
+      alert('년, 월, 일을 모두 선택해주세요!');
+      return;
+    }
+
+    const targetDate = `${year.slice(2)}-${month}-${day}`; // 예: "2025-07-15"
+    const db = getDatabase();
+    const usersRef = ref(db, 'users');
+    console.log('선택한 날짜:', targetDate);
+
+
+    try {
+      const snapshot = await get(usersRef);
+      if (snapshot.exists()) {
+        const usersData = snapshot.val();
+        let resultList = [];
+
+        Object.entries(usersData).forEach(([uid, userInfo]) => {
+          console.log('확인 중인 유저:', userInfo.name);
+          console.log('해당 유저 예약:', userInfo.reservations);
+          const { name, email, reservations } = userInfo;
+
+          if (reservations) {
+            Object.values(reservations).forEach((res) => {
+              console.log('예약 date:', res.date, 'vs targetDate:', targetDate);
+
+              if (res.date === targetDate) {
+                resultList.push({
+                  name,
+                  email,
+                  route: res.route || '',
+                  time: res.time || '',
+                  canceled: false // 현재 구조엔 취소 여부가 없으므로 기본 false 처리
+                });
+                console.log('일치하는 예약 발견:', res);
+              }
+            });
+          }
+        });
+
+        // 이름 검색어 필터
+        if (searchName.trim() !== '') {
+          resultList = resultList.filter(item =>
+            item.name.includes(searchName.trim())
+          );
+        }
+
+        setReservationList(resultList);
+        setFilteredData(resultList);
+      } else {
+        setReservationList([]);
+        setFilteredData([]);
+        alert('예약 데이터가 없습니다.');
+      }
+    } catch (error) {
+      console.error('에러 발생:', error);
+      alert('예약 데이터를 불러오는 중 오류가 발생했습니다.');
+    }
+  };
+
+  const [filteredRouteStats, setFilteredRouteStats] = useState([]);
+  const [chartYear, setChartYear] = useState('');
+  const [chartMonth, setChartMonth] = useState('');
+  const [chartDay, setChartDay] = useState('');
+
+  const handleChartYearChange = (e) => setChartYear(e.target.value);
+  const handleChartMonthChange = (e) => setChartMonth(e.target.value);
+  const handleChartDayChange = (e) => setChartDay(e.target.value);
+
+
+  const handleChartSearch = async () => {
+    const db = getDatabase();
+    const usersRef = ref(db, 'users');
+    const snapshot = await get(usersRef);
+    if (!snapshot.exists()) return;
+
+    const usersData = snapshot.val();
+    const counts = {};
+
+    // 🟡 필터 값 직접 계산
+    let dynamicFilter = '';
+    if (statType === 'route') {
+      const shortYear = chartYear ? chartYear.slice(2) : '';
+      dynamicFilter = [shortYear, chartMonth, chartDay].filter(Boolean).join('-');
+    } else if (statType === 'station' || statType === 'time') {
+      dynamicFilter = selectedRoute; // 노선 이름 기반
+    }
+
+    Object.values(usersData).forEach(user => {
+      const reservations = user.reservations || {};
+      Object.values(reservations).forEach(res => {
+        if (statType === 'route' && res.date === dynamicFilter) {
+          const route = res.route || '기타';
+          counts[route] = (counts[route] || 0) + 1;
+        }
+        if (statType === 'station' && res.route === dynamicFilter) {
+          const station = res.station || '미지정';
+          counts[station] = (counts[station] || 0) + 1;
+        }
+        if (statType === 'time' && res.route === dynamicFilter) {
+          const time = res.time || '00:00';
+          counts[time] = (counts[time] || 0) + 1;
+        }
+        if (statType === 'routeTotal') {
+          const route = res.route || '기타';
+          counts[route] = (counts[route] || 0) + 1;
+        }
+      });
+    });
+
+    const data = Object.entries(counts).map(([name, count]) => ({ name, count }));
+    setFilteredRouteStats(data);
+  };
+
+ 
+  const [statType, setStatType] = useState('routeTotal');
+
+   useEffect(() => {
+  // 탭이 열릴 때 최초 한 번만 실행
+    if (statType === 'routeTotal') {
+      handleChartSearch();
+    }
+  }, [statType]);
+
+  const [filterValue, setFilterValue] = useState(''); // 날짜 or 노선명 등
+  const [chartData, setChartData] = useState([]);
+  const [selectedRoute, setSelectedRoute] = useState('');
+  const [routeList, setRouteList] = useState([]);
+
+  useEffect(() => {
+    const fetchRouteNames = async () => {
+      const db = getDatabase();
+      const routeRef = ref(db, 'routes');
+      const snapshot = await get(routeRef);
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+        const routeNames = Object.values(data)
+          .map((route) => route.name)
+          .filter(Boolean); // name이 undefined/null인 경우 제외
+        setRouteList(routeNames);
+      }
+    };
+
+    fetchRouteNames();
+  }, []);
+
+
+
+  const handleStatTypeChange = (e) => {
+    const selectedType = e.target.value;
+    setStatType(selectedType);
+    setFilterValue(''); // 유형이 바뀌면 필터 초기화
+  };
+
+
   return (
     <Box sx={{ width: '100%' }}>
       
@@ -39,17 +220,14 @@ const ReservationManagement = () => {
           onChange={handleTabChange}
           textColor="primary"
           indicatorColor="primary"
-          variant="standard" // ← 요거!
-          centered             // ← 요거!
+          variant="standard" 
+          centered            
           sx={{
-            minWidth: 'fit-content',  // ← 너무 좁게 붙는 거 방지
-          }}
+            minWidth: 'fit-content', }}
         >
           <Tab label="날짜별 예약자 목록" />
-          <Tab label="예약 상세 정보 조회" />
           <Tab label="예약 통계" />
           <Tab label="예약 취소 분석" />
-          <Tab label="No-Show 기록" />
         </Tabs>
       </Box>
 
@@ -64,13 +242,174 @@ const ReservationManagement = () => {
           maxWidth: 'none',
         }}
       >
-        <TabPanel value={tabIndex} index={0}>날짜별 예약 목록</TabPanel>
-        <TabPanel value={tabIndex} index={1}>예약 상세 정보 조회</TabPanel>
-        <TabPanel value={tabIndex} index={2}>예약 통계</TabPanel>
-        <TabPanel value={tabIndex} index={3}>예약 취소 분석</TabPanel>
-        <TabPanel value={tabIndex} index={4}>No-Show 기록</TabPanel>
-      </Box>
-    </Box>
+        <TabPanel value={tabIndex} index={0}> 
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2,}}>
+            <FormControl sx={{ width: 150 }}>
+              <InputLabel>년도</InputLabel>
+              <Select value={year} onChange={handleYearChange}>
+                <MenuItem value="2023">2023</MenuItem>
+                <MenuItem value="2024">2024</MenuItem>
+                <MenuItem value="2025">2025</MenuItem>
+              </Select>
+            </FormControl>
+
+            <FormControl sx={{ width: 150 }}>
+              <InputLabel>월</InputLabel>
+              <Select value={month} onChange={handleMonthChange}>
+                {Array.from({ length: 12 }, (_, i) => (
+                  <MenuItem key={i + 1} value={String(i + 1).padStart(2, '0')}>
+                    {i + 1}월
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl sx={{ width: 150 }}>
+              <InputLabel>일</InputLabel>
+              <Select value={day} onChange={handleDayChange}>
+                {Array.from({ length: 31 }, (_, i) => (
+                  <MenuItem key={i + 1} value={String(i + 1).padStart(2, '0')}>
+                    {i + 1}일
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <TextField
+              label="이름 검색"
+              variant="outlined"
+              value={searchName}
+              sx={{ width: 300 }}
+              onChange={e => setSearchName(e.target.value)}
+            />
+            
+            <Button variant="contained" onClick={handleSearch}>조회</Button>
+          </Box>
+          <Paper
+            elevation={2}
+            sx={{
+              backgroundColor: '#fff',
+              padding: 2,
+              mt: 2,
+              borderRadius: 2,
+            }}
+          >
+            {/* 라벨 헤더 줄 */}
+            <Box sx={{ display: 'flex', mb: 1 }}>
+              <Typography sx={{ width: 200, fontWeight: 'bold' }}>이메일</Typography>
+              <Typography sx={{ width: 200, fontWeight: 'bold' }}>이름</Typography>
+              <Typography sx={{ width: 200, fontWeight: 'bold' }}>노선</Typography>
+              <Typography sx={{ width: 200, fontWeight: 'bold' }}>출발 시간</Typography>
+              <Typography sx={{ width: 200, fontWeight: 'bold' }}>취소 여부</Typography>
+            </Box>
+
+            {/* 데이터 줄들 */}
+            {filteredData.length > 0 ? (
+              filteredData.map((item, index) => (
+                <Box
+                  key={index}
+                  sx={{
+                    display: 'flex',
+                    py: 1,
+                    borderBottom: '1px solid #eee'
+                  }}
+                >
+                  <Typography sx={{ width: 200 }}>{item.email}</Typography>
+                  <Typography sx={{ width: 200 }}>{item.name}</Typography>
+                  <Typography sx={{ width: 200 }}>{item.route}</Typography>
+                  <Typography sx={{ width: 200 }}>{item.time}</Typography>
+                  <Typography sx={{ width: 200 }}>
+                    {item.canceled ? '취소됨' : '예약 중'}
+                  </Typography>
+                </Box>
+              ))
+            ) : (
+              <Typography sx={{ py: 2, textAlign: 'center' }}>
+                조회된 예약이 없습니다.
+              </Typography>
+            )}
+          </Paper>
+
+          </TabPanel>
+          <TabPanel value={tabIndex} index={1}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 5}}>
+              <FormControl sx={{ width: 200 }}>
+                <InputLabel>통계 유형</InputLabel>
+                <Select value={statType} onChange={handleStatTypeChange}>
+                  <MenuItem value="route">날짜별 노선별 예약 수</MenuItem>
+                  <MenuItem value="station">노선별 정류장 예약 수</MenuItem>
+                  <MenuItem value="time">노선별 시간대 예약 수</MenuItem>
+                  <MenuItem value="routeTotal">전체 노선 누적 예약 수</MenuItem>
+                </Select>
+              </FormControl>
+              {statType === 'route' && (
+              <>
+                {/* chartYear, chartMonth, chartDay 드롭다운 그대로 사용! */}
+                <FormControl sx={{ width: 150 }}>
+                  <InputLabel>년도</InputLabel>
+                  <Select value={chartYear} onChange={handleChartYearChange}>
+                    <MenuItem value="">전체</MenuItem>
+                    <MenuItem value="2023">2023</MenuItem>
+                    <MenuItem value="2024">2024</MenuItem>
+                    <MenuItem value="2025">2025</MenuItem>
+                  </Select>
+                </FormControl>
+
+                <FormControl sx={{ width: 150 }}>
+                  <InputLabel>월</InputLabel>
+                  <Select value={chartMonth} onChange={handleChartMonthChange}>
+                    <MenuItem value="">전체</MenuItem>
+                    {Array.from({ length: 12 }, (_, i) => (
+                      <MenuItem key={i + 1} value={String(i + 1).padStart(2, '0')}>
+                        {i + 1}월
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <FormControl sx={{ width: 150 }}>
+                  <InputLabel>일</InputLabel>
+                  <Select value={chartDay} onChange={handleChartDayChange}>
+                    <MenuItem value="">전체</MenuItem>
+                    {Array.from({ length: 31 }, (_, i) => (
+                      <MenuItem key={i + 1} value={String(i + 1).padStart(2, '0')}>
+                        {i + 1}일
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </>
+            )}
+
+            {/* 2. 노선 기준 정류장 통계 or 시간대 통계일 경우 */}
+            {(statType === 'station' || statType === 'time') && (
+              <FormControl sx={{ width: 200 }}>
+                <InputLabel>노선 선택</InputLabel>
+                <Select value={selectedRoute} onChange={(e) => setSelectedRoute(e.target.value)}>
+                  {routeList.map((route) => (
+                    <MenuItem key={route} value={route}>{route}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+              
+              
+              <Button variant="contained" onClick={handleChartSearch}>조회</Button>
+            </Box>
+            <ResponsiveContainer width="100%" height={350}>
+              <BarChart data={filteredRouteStats}>
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="count" fill="#FABE00" barSize={50} />
+              </BarChart>
+            </ResponsiveContainer>
+
+          </TabPanel>
+                  <TabPanel value={tabIndex} index={2}>시간대별 취소, 노선대별 취소, 등등</TabPanel>
+                  
+                </Box>
+              </Box>
   );
 };
 

--- a/refacbus_admin/src/pages/UserManagement.jsx
+++ b/refacbus_admin/src/pages/UserManagement.jsx
@@ -95,7 +95,6 @@ const UserManagement = () => {
       type: isBan ? 'ban' : isWarning ? 'warning' : 'note'
     };
 
-    // 📌 memo는 배열 대신 push로 저장
     await push(memoRef, newMemo);
 
     const snapshot = await get(userRef);
@@ -110,12 +109,10 @@ const UserManagement = () => {
       updates.isBanned = true;
     }
 
-    // 상태 관련 업데이트 (memo 제외)
     if (Object.keys(updates).length > 0) {
       await update(userRef, updates);
     }
 
-    // 로컬 상태 반영
     setAllUsers((prev) =>
       prev.map((u) =>
         u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
@@ -134,7 +131,6 @@ const UserManagement = () => {
     const handleUnban = async (uid) => {
     await update(ref(realtimeDb, `users/${uid}`), { isBanned: false });
 
-    // 👉 상태 업데이트
     setAllUsers((prev) =>
       prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
     );
@@ -178,7 +174,7 @@ const UserManagement = () => {
 
   const handleOpenReset = (user) => {
     setTargetUser(user);
-    setResetEmail(user.email); // 👉 디폴트 이메일
+    setResetEmail(user.email); 
     setIsResetOpen(true);
   };
 
@@ -334,7 +330,6 @@ const UserManagement = () => {
               name: editedName,
             });
 
-            // 🔄 로컬 상태도 갱신
             setAllUsers((prev) =>
               prev.map((u) => u.uid === editingUser.uid ? { ...u, email: editedEmail, name: editedName } : u)
             );

--- a/refacbus_admin/src/utils/colorUnits.js
+++ b/refacbus_admin/src/utils/colorUnits.js
@@ -3,12 +3,11 @@
 const colorPalette = [
   "#FFCDD2", "#F8BBD0", "#E1BEE7", "#D1C4E9",
   "#BBDEFB", "#B2EBF2", "#C8E6C9", "#FFF9C4",
-  "#FFE0B2", "#D7CCC8",
+  "#FFE0B2", "#D7CCC8", "#FABE00"
 ];
 
-// route 이름을 고유한 색으로 매핑
 export const getColorByRoute = (routeName) => {
-  if (!routeName) return "#ffffff"; // fallback
+  if (!routeName) return "#ffffff"; 
   const hash = Array.from(routeName)
     .reduce((acc, char) => acc + char.charCodeAt(0), 0);
   return colorPalette[hash % colorPalette.length];


### PR DESCRIPTION
## 설명
예약 통계 탭 내에서 다양한 기준(노선, 정류장, 시간대, 날짜 등)으로 예약 수 데이터를 조회할 수 있도록 드롭다운 필터를 추가하고, 하나의 막대그래프로 시각화하는 기능을 구현했습니다.  

또한, 해당 탭에 처음 진입 시 전체 노선 누적 예약 수를 기본적으로 보여주도록 설정했습니다.

---

## 구현 내용 요약
- 통계 유형(노선별/정류장별/시간대별/전체 누적) 드롭다운 추가
- 유형에 따라 노선 or 날짜 선택 드롭다운이 동적으로 표시되도록 구성
- Firebase에서 사용자 예약 정보를 불러와 선택 기준에 맞게 카운트 처리
- 하나의 BarChart 컴포넌트로 모든 유형 통계 시각화
- 탭 최초 진입 시 '전체 노선 누적 예약 수' 자동 조회 처리
- `chartYear`, `chartMonth`, `chartDay`를 조합하여 날짜 필터 적용 가능
- routeList 동기화 및 드롭다운 연결

---

## 관련 변경사항
- `ReservationManagement.jsx`
  - `handleChartSearch`, `handleStatTypeChange`, `chartYear/Month/Day` 핸들러 추가
  - `routeList`, `selectedRoute`, `statType`, `filterValue` 관련 상태 추가
  - Firebase 조회 로직 개선
  - BarChart 한 개만 사용하며 props 변경 방식으로 재활용
- `routes` 경로에서 노선 이름 동기화(fetch)

---

## 참고사항
- Firebase에서 예약 날짜가 `YY-MM-DD` 형식으로 저장되어 있어, 검색용 날짜 포맷도 동일하게 변환함 (`slice(-2)` 사용)
- 데이터 개수가 적을 때 막대 너비가 너무 넓어지는 문제는 `barSize` 속성으로 해결함

---

## 테스트 방법
- [ ] 1. 관리자 페이지 → 예약 통계 탭 클릭
- [ ] 2. 통계 유형 드롭다운 선택 (노선/정류장/시간대/전체 누적)
- [ ] 3. 조건에 맞게 날짜 또는 노선 선택 후 `조회` 클릭
- [ ] 4. 막대그래프에 올바르게 데이터가 표시되는지 확인
- [ ] 5. 탭 진입 시 전체 누적 예약 수가 기본 표시되는지 확인

