### PR TITLE
Feature/reservation management

### DIFF
--- a/refacbus_admin/src/pages/ReservationManagement.jsx
+++ b/refacbus_admin/src/pages/ReservationManagement.jsx
@@ -194,14 +194,137 @@ const ReservationManagement = () => {
     fetchRouteNames();
   }, []);
 
-
-
   const handleStatTypeChange = (e) => {
     const selectedType = e.target.value;
     setStatType(selectedType);
     setFilterValue(''); // 유형이 바뀌면 필터 초기화
   };
 
+  const [allDeletedReservations, setAllDeletedReservations] = useState([]);
+  const [deleteType, setDeleteType] = useState("routeTotal"); // 기본값은 "route"
+  const [filteredRouteDeletes, setFilteredRouteDeletes] = useState([]);
+
+
+  useEffect(() => {
+    const db = getDatabase();
+    const usersRef = ref(db, "users");
+
+    get(usersRef).then((snapshot) => {
+      const all = [];
+      snapshot.forEach((userSnap) => {
+        const reservations = userSnap.child("reservations");
+        reservations.forEach((resSnap) => {
+          const data = resSnap.val();
+          if (data.deleted === true) {
+            all.push({
+              route: data.route,
+              time: data.time,
+              date: data.date,
+              reason: data.reason,
+            });
+          }
+        });
+      });
+      setAllDeletedReservations(all);
+    });
+  }, []);
+  
+
+
+  const [deleteYear, setDeleteYear] = useState('');
+  const [deleteMonth, setDeleteMonth] = useState('');
+  const [deleteDay, setDeleteDay] = useState('');
+  const [selectedTime, setSelectedTime] = useState('');
+
+  const handleDeleteYearChange = (e) => setDeleteYear(e.target.value);
+  const handleDeleteMonthChange = (e) => setDeleteMonth(e.target.value);
+  const handleDeleteDayChange = (e) => setDeleteDay(e.target.value);
+
+  const handleDeleteChange = (event) => {
+    setDeleteType(event.target.value);
+    
+  };
+
+  const handleDeleteSearch = () => {
+    let result = [];
+
+    const formatDate = (dateStr) => {
+      // 예: 25-07-21 → 2025-07-21
+      const [yy, mm, dd] = dateStr.split("-");
+      return `20${yy}-${mm}-${dd}`;
+    };
+     console.log("🔥 전체 삭제된 예약", allDeletedReservations);
+
+    const filtered = allDeletedReservations.filter((r) => {
+      if (!r.date) return false;
+
+      const fullDate = formatDate(r.date); // "2025-07-21"
+      const [year, month, day] = fullDate.split("-");
+
+      const match =
+        (!deleteYear || year === deleteYear) &&
+        (!deleteMonth || month === deleteMonth) &&
+        (!deleteDay || day === deleteDay);
+
+      console.log("🧐 비교중:", { r, fullDate, year, month, day, match });
+
+      return match;
+    });
+
+    console.log("📊 필터 결과:", filtered);
+
+    if (deleteType === "route") {
+      // 날짜별 취소 노선 수 (필터 반영된 데이터 사용)
+      const grouped = {};
+      filtered.forEach((r) => {
+        const key = `${r.route}`;
+        grouped[key] = (grouped[key] || 0) + 1;
+      });
+      result = Object.entries(grouped).map(([name, count]) => ({ name, count }));
+    }
+    console.log("📊 처리된 데이터:", result);
+
+    if (deleteType === "time") {
+      const grouped = {};
+
+      allDeletedReservations
+        .filter((r) => selectedTime === "" || r.route === selectedTime)
+        .forEach((r) => {
+          const key = r.time;
+          grouped[key] = (grouped[key] || 0) + 1;
+        });
+
+        result = Object.entries(grouped).map(([name, count]) => ({ name, count }));
+      }
+
+
+    if (deleteType === "routeTotal") {
+      const grouped = {};
+      allDeletedReservations.forEach((r) => {
+        grouped[r.route] = (grouped[r.route] || 0) + 1;
+      });
+      result = Object.entries(grouped).map(([name, count]) => ({ name, count }));
+    }
+
+    if (deleteType === "reason") {
+      const grouped = {};
+      allDeletedReservations.forEach((r) => {
+        const reasons = r.reason?.split(",") ?? [];
+        reasons.forEach((re) => {
+          const trimmed = re.trim();
+          grouped[trimmed] = (grouped[trimmed] || 0) + 1;
+        });
+      });
+      result = Object.entries(grouped).map(([name, count]) => ({ name, count }));
+    }
+
+    setFilteredRouteDeletes(result);
+  };
+
+
+  
+
+  
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -406,7 +529,76 @@ const ReservationManagement = () => {
             </ResponsiveContainer>
 
           </TabPanel>
-                  <TabPanel value={tabIndex} index={2}>시간대별 취소, 노선대별 취소, 등등</TabPanel>
+        <TabPanel value={tabIndex} index={2}><Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 5}}>
+              <FormControl sx={{ width: 200 }}>
+                <InputLabel>통계 유형</InputLabel>
+                <Select value={deleteType} onChange={handleDeleteChange}>
+                  <MenuItem value="route">날짜별 취소 노선 수</MenuItem>
+                  <MenuItem value="time">노선별 취소 시간대</MenuItem>
+                  <MenuItem value="routeTotal">전체 취소 노선 수</MenuItem>
+                  <MenuItem value="reason">전체 취소 사유</MenuItem>
+                </Select>
+              </FormControl>
+              {deleteType === 'route' && (
+              <>
+                {/* chartYear, chartMonth, chartDay 드롭다운 그대로 사용! */}
+                <FormControl sx={{ width: 150 }}>
+                  <InputLabel>년도</InputLabel>
+                  <Select value={deleteYear} onChange={handleDeleteYearChange}>
+                    <MenuItem value="">전체</MenuItem>
+                    <MenuItem value="2023">2023</MenuItem>
+                    <MenuItem value="2024">2024</MenuItem>
+                    <MenuItem value="2025">2025</MenuItem>
+                  </Select>
+                </FormControl>
+
+                <FormControl sx={{ width: 150 }}>
+                  <InputLabel>월</InputLabel>
+                  <Select value={deleteMonth} onChange={handleDeleteMonthChange}>
+                    <MenuItem value="">전체</MenuItem>
+                    {Array.from({ length: 12 }, (_, i) => (
+                      <MenuItem key={i + 1} value={String(i + 1).padStart(2, '0')}>
+                        {i + 1}월
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <FormControl sx={{ width: 150 }}>
+                  <InputLabel>일</InputLabel>
+                  <Select value={deleteDay} onChange={handleDeleteDayChange}>
+                    <MenuItem value="">전체</MenuItem>
+                    {Array.from({ length: 31 }, (_, i) => (
+                      <MenuItem key={i + 1} value={String(i + 1).padStart(2, '0')}>
+                        {i + 1}일
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </>
+            )}
+            {(deleteType === 'time') && (
+              <FormControl sx={{ width: 200 }}>
+                <InputLabel>노선 선택</InputLabel>
+                <Select value={selectedTime} onChange={(e) => setSelectedTime(e.target.value)}>
+                  {routeList.map((route) => (
+                    <MenuItem key={route} value={route}>{route}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+              <Button variant="contained" onClick={handleDeleteSearch}>조회</Button>
+            </Box>
+            <ResponsiveContainer width="100%" height={350}>
+              <BarChart data={filteredRouteDeletes}>
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="count" fill="#FABE00" barSize={50} />
+              </BarChart>
+            </ResponsiveContainer>
+          </TabPanel>
                   
                 </Box>
               </Box>

--- a/refacbus_admin/src/pages/ReservationManagement.jsx
+++ b/refacbus_admin/src/pages/ReservationManagement.jsx
@@ -56,7 +56,6 @@ const ReservationManagement = () => {
     const targetDate = `${year.slice(2)}-${month}-${day}`; // 예: "2025-07-15"
     const db = getDatabase();
     const usersRef = ref(db, 'users');
-    console.log('선택한 날짜:', targetDate);
 
 
     try {
@@ -66,14 +65,10 @@ const ReservationManagement = () => {
         let resultList = [];
 
         Object.entries(usersData).forEach(([uid, userInfo]) => {
-          console.log('확인 중인 유저:', userInfo.name);
-          console.log('해당 유저 예약:', userInfo.reservations);
           const { name, email, reservations } = userInfo;
 
           if (reservations) {
             Object.values(reservations).forEach((res) => {
-              console.log('예약 date:', res.date, 'vs targetDate:', targetDate);
-
               if (res.date === targetDate) {
                 resultList.push({
                   name,
@@ -82,7 +77,6 @@ const ReservationManagement = () => {
                   time: res.time || '',
                   canceled: false // 현재 구조엔 취소 여부가 없으므로 기본 false 처리
                 });
-                console.log('일치하는 예약 발견:', res);
               }
             });
           }
@@ -103,7 +97,6 @@ const ReservationManagement = () => {
         alert('예약 데이터가 없습니다.');
       }
     } catch (error) {
-      console.error('에러 발생:', error);
       alert('예약 데이터를 불러오는 중 오류가 발생했습니다.');
     }
   };
@@ -127,7 +120,7 @@ const ReservationManagement = () => {
     const usersData = snapshot.val();
     const counts = {};
 
-    // 🟡 필터 값 직접 계산
+    // 필터 값 직접 계산
     let dynamicFilter = '';
     if (statType === 'route') {
       const shortYear = chartYear ? chartYear.slice(2) : '';
@@ -253,7 +246,6 @@ const ReservationManagement = () => {
       const [yy, mm, dd] = dateStr.split("-");
       return `20${yy}-${mm}-${dd}`;
     };
-     console.log("🔥 전체 삭제된 예약", allDeletedReservations);
 
     const filtered = allDeletedReservations.filter((r) => {
       if (!r.date) return false;
@@ -266,12 +258,9 @@ const ReservationManagement = () => {
         (!deleteMonth || month === deleteMonth) &&
         (!deleteDay || day === deleteDay);
 
-      console.log("🧐 비교중:", { r, fullDate, year, month, day, match });
-
       return match;
     });
 
-    console.log("📊 필터 결과:", filtered);
 
     if (deleteType === "route") {
       // 날짜별 취소 노선 수 (필터 반영된 데이터 사용)
@@ -282,7 +271,6 @@ const ReservationManagement = () => {
       });
       result = Object.entries(grouped).map(([name, count]) => ({ name, count }));
     }
-    console.log("📊 처리된 데이터:", result);
 
     if (deleteType === "time") {
       const grouped = {};


### PR DESCRIPTION
## 설명 (Description)

관리자 페이지 내 **예약 취소 통계 기능**을 추가했습니다.  
삭제된 예약 데이터를 기반으로 다양한 유형의 취소 통계를 시각화하며, 선택한 조건에 따라 동적으로 그래프를 렌더링합니다.

---

## 구현 (What I did)

- Firebase Realtime Database에서 삭제된 예약(`deleted === true`)만 조회
- 통계 유형에 따라 막대 그래프 형태로 시각화:
  - 날짜별 취소 노선 수
  - 노선별 취소 시간대
  - 전체 취소 노선 수
  - 전체 취소 사유
- 조건별 필터링 기능 추가 (예: 연/월/일 선택, 노선 선택 등)
- Recharts를 이용한 BarChart 구성

---

## 관련 변경사항 (Changes)

- `deleteType`, `deleteYear`, `deleteMonth`, `deleteDay`, `selectedTime` 등 상태 변수 추가
- `handleDeleteSearch()` 함수에서 통계 유형별 데이터 가공 로직 작성
- UI 상단에 `<Select>` 및 날짜 필터 드롭다운 추가
- 통계 패널(TabPanel index 2)에 ResponsiveContainer + BarChart 추가

---

## 참고사항 (Notes)

- Firebase 데이터의 `date` 필드는 `"yy-MM-dd"` 형식이므로, 연도 앞에 `"20"`을 붙여 비교하도록 처리
- `reason` 필드는 쉼표로 여러 개 저장될 수 있으므로, `split(",") + trim()`을 통해 분리 처리
- 통계 유형이 `"route"`일 경우에만 날짜 필터(`연/월/일`)가 나타나도록 조건 분기 처리함
- 사용자가 필터를 선택하지 않으면 전체 조건으로 조회됨

---

## 테스트 방법 (How to test)

- [ ] 1. 관리자 페이지 → "예약 취소 통계" 탭으로 이동
- [ ] 2. 통계 유형 드롭다운에서 각 항목 선택 후 "조회" 버튼 클릭
- [ ] 3. 필터 조건에 맞는 막대그래프가 정상적으로 렌더링되는지 확인
- [ ] 4. 취소 사유가 여러 개인 경우, 각각 분리되어 카운팅되는지 확인
- [ ] 5. 연/월/일 필터를 조합해 조회 조건이 제대로 작동하는지 확인
