### PR TITLE
ManagerManagement.jsx 일부 구현 완료

### DIFF
--- a/refacbus_admin/src/components/DashBoardSchedule/ScheduleCardBox.jsx
+++ b/refacbus_admin/src/components/DashBoardSchedule/ScheduleCardBox.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from "react";
+import { getDatabase, ref, get } from "firebase/database";
+import { Box, Typography, Paper, Grid } from "@mui/material";
+
+const ScheduleCardBox = () => {
+  const [scheduleList, setScheduleList] = useState([]);
+  
+
+  useEffect(() => {
+    const fetchSchedules = async () => {
+      const db = getDatabase();
+      const scheduleRef = ref(db, "managerSchedules");
+      const snapshot = await get(scheduleRef);
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+        const parsed = Object.entries(data).map(([date, content]) => ({
+          date,
+          content,
+        }));
+        setScheduleList(parsed);
+      }
+    };
+
+    fetchSchedules();
+  }, []);
+
+  return (
+    <Box sx={{ mt: 3, p: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        일정 목록
+      </Typography>
+      <Grid container spacing={2}>
+        {scheduleList.map((item, index) => (
+          <Grid item xs={12} sm={6} md={4} key={index}>
+            <Paper
+              elevation={3}
+              sx={{
+                p: 2,
+                borderRadius: 2,
+                height: 120,
+                backgroundColor: "#f0f4ff",
+              }}
+            >
+              <Typography variant="subtitle1" fontWeight="bold">
+                {item.date}
+              </Typography>
+              {Object.values(item.content).map((schedule, i) => (
+                <Typography key={i} variant="body2" mt={1}>
+                  {schedule.text}
+                </Typography>
+              ))}
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default ScheduleCardBox;

--- a/refacbus_admin/src/components/Manager_Schedule.jsx
+++ b/refacbus_admin/src/components/Manager_Schedule.jsx
@@ -1,0 +1,212 @@
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Select,
+  Paper,
+  Typography,
+} from "@mui/material";
+import "react-calendar/dist/Calendar.css";
+import { getDatabase, ref, push, get } from "firebase/database";
+import { getAuth } from "firebase/auth";
+import SharedCalendar from "../components/calendar/SharedCalendar";
+
+const Manager_Schedule = () => {
+  const [value, setValue] = useState(new Date());
+  const [open, setOpen] = useState(false);
+  const [year, setYear] = useState("");
+  const [month, setMonth] = useState("");
+  const [day, setDay] = useState("");
+  const [schedule, setSchedule] = useState("");
+  const [markedDates, setMarkedDates] = useState([]);
+  const [schedules, setSchedules] = useState([]);
+
+  useEffect(() => {
+    const fetchMarkedDates = async () => {
+      const db = getDatabase();
+      const scheduleRef = ref(db, "managerSchedules");
+      const snapshot = await get(scheduleRef);
+
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+
+        const uniqueDates = new Set();
+        const scheduleList = [];
+
+        for (const date of Object.keys(data)) {
+          const entries = Object.values(data[date]);
+          if (entries.length > 0) {
+            uniqueDates.add(date);
+          }
+          entries.forEach((item) => {
+            scheduleList.push({
+              date,
+              text: item.text || "",
+            });
+          });
+        }
+
+        setMarkedDates(Array.from(uniqueDates));
+        setSchedules(scheduleList);
+      }
+    };
+
+    fetchMarkedDates();
+  }, []);
+
+  const handleAddClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleSave = () => {
+    if (!year || !month || !day || !schedule.trim()) {
+      alert("모든 값을 입력해주세요!");
+      return;
+    }
+
+    const db = getDatabase();
+    const auth = getAuth();
+    const uid = auth.currentUser?.uid;
+
+    if (!uid) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
+
+    const dateKey = `${year}-${month}-${day}`;
+
+    const scheduleData = {
+      date: dateKey,
+      text: schedule.trim(),
+      createdAt: new Date().toISOString(),
+      uid: uid,
+    };
+
+    push(ref(db, `managerSchedules/${dateKey}`), scheduleData)
+      .then(() => {
+        alert("일정이 저장되었습니다!");
+        setOpen(false);
+        setYear("");
+        setMonth("");
+        setDay("");
+        setSchedule("");
+        setMarkedDates((prev) => [...new Set([...prev, dateKey])]);
+        setSchedules((prev) => [...prev, { date: dateKey, text: schedule.trim() }]);
+      })
+      .catch((error) => {
+        console.error("일정 저장 오류:", error);
+        alert("일정 저장에 실패했습니다.");
+      });
+  };
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      {/* 캘린더 + 일정 목록 + 버튼 */}
+      <Box sx={{ display: "flex", gap: 2, alignItems: "flex-start" }}>
+        <SharedCalendar
+          value={value}
+          onChange={setValue}
+          markedDates={markedDates}
+        />
+
+        {/* 일정 목록 */}
+        <Box
+          sx={{
+            minWidth: "200px",
+            p: 2,
+            border: "1px solid #ccc",
+            borderRadius: 2,
+            backgroundColor: "#f9f9f9",
+          }}
+        >
+          <Typography variant="h6" gutterBottom>
+            📋 등록된 일정
+          </Typography>
+          {schedules.map((s, i) => (
+            <Box key={i} sx={{ mb: 1 }}>
+              <strong>{s.date}</strong>
+              <br />
+              {s.text}
+            </Box>
+          ))}
+        </Box>
+
+        {/* 일정 추가 버튼 */}
+        <Box sx={{ alignSelf: "center" }}>
+          <Button variant="contained" onClick={handleAddClick}>
+            일정 추가
+          </Button>
+        </Box>
+      </Box>
+
+      {/* 일정 추가 모달 */}
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>📅 일정 등록</DialogTitle>
+        <DialogContent
+          sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}
+        >
+          <Box sx={{ display: "flex", gap: 2 }}>
+            <FormControl sx={{ width: 100 }}>
+              <InputLabel>년도</InputLabel>
+              <Select value={year} onChange={(e) => setYear(e.target.value)}>
+                <MenuItem value="2025">2025</MenuItem>
+                <MenuItem value="2024">2024</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl sx={{ width: 100 }}>
+              <InputLabel>월</InputLabel>
+              <Select value={month} onChange={(e) => setMonth(e.target.value)}>
+                {Array.from({ length: 12 }, (_, i) => (
+                  <MenuItem key={i + 1} value={String(i + 1).padStart(2, "0")}>
+                    {i + 1}월
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl sx={{ width: 100 }}>
+              <InputLabel>일</InputLabel>
+              <Select value={day} onChange={(e) => setDay(e.target.value)}>
+                {Array.from({ length: 31 }, (_, i) => (
+                  <MenuItem key={i + 1} value={String(i + 1).padStart(2, "0")}>
+                    {i + 1}일
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+
+          <TextField
+            label="일정 내용"
+            variant="outlined"
+            fullWidth
+            multiline
+            rows={3}
+            value={schedule}
+            onChange={(e) => setSchedule(e.target.value)}
+          />
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={handleClose}>취소</Button>
+          <Button onClick={handleSave} variant="contained">
+            저장
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default Manager_Schedule;

--- a/refacbus_admin/src/components/calendar/SharedCalendar.css
+++ b/refacbus_admin/src/components/calendar/SharedCalendar.css
@@ -1,0 +1,12 @@
+.highlight {
+  background-color: #FABE00; /* 파란 배경 */
+  color: black;
+  border-radius: 50%;
+  font-weight: bold;
+}
+.react-calendar__tile.highlight {
+  background: #90caf9 !important;
+  color: white;
+  border-radius: 50%;
+  font-weight: bold;
+}

--- a/refacbus_admin/src/components/calendar/SharedCalendar.jsx
+++ b/refacbus_admin/src/components/calendar/SharedCalendar.jsx
@@ -1,0 +1,49 @@
+// components/SharedCalendar.jsx
+import React from "react";
+import Calendar from "react-calendar";
+import Paper from "@mui/material/Paper";
+import "./SharedCalendar.css"; 
+
+
+const SharedCalendar = ({ value, onChange, markedDates = [] }) => {
+  const tileClassName = ({ date, view }) => {
+    if (view === "month") {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      const dateStr = `${year}-${month}-${day}`;
+
+      if (markedDates.includes(dateStr)) {
+        return "highlight";
+      }
+    }
+    return null;
+  };
+
+
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        width: 500,
+        height: 400,
+        p: 2,
+        borderRadius: 2,
+        "& .react-calendar": {
+          width: "100%",
+          height: "100%",
+          fontSize: "1.2rem",
+        },
+      }}
+    >
+      <Calendar
+        onChange={onChange}
+        value={value}
+        className="custom-calendar"
+        tileClassName={tileClassName}
+      />
+    </Paper>
+  );
+};
+
+export default SharedCalendar;

--- a/refacbus_admin/src/pages/DashBoard.jsx
+++ b/refacbus_admin/src/pages/DashBoard.jsx
@@ -3,11 +3,16 @@ import Box from '@mui/material/Box';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import { Typography, List, ListItemButton, ListItemText, Paper } from '@mui/material';
-import { getDatabase, ref, onValue } from 'firebase/database';
+import { getDatabase, ref, onValue, get } from 'firebase/database';
+import SharedCalendar from "../components/calendar/SharedCalendar";
+import ScheduleCardBox from "../components/DashBoardSchedule/ScheduleCardBox"; 
+
 
 const Dashboard = () => {
   const [value, setValue] = useState(new Date());
   const [notices, setNotices] = useState([]);
+  const [markedDates, setMarkedDates] = useState([]);
+
 
   useEffect(() => {
     const db = getDatabase();
@@ -22,6 +27,32 @@ const Dashboard = () => {
     });
   }, []);
 
+  useEffect(() => {
+    const fetchMarkedDates = async () => {
+          const db = getDatabase();
+          const scheduleRef = ref(db, "managerSchedules");
+          const snapshot = await get(scheduleRef);
+    
+          if (snapshot.exists()) {
+            const data = snapshot.val();
+    
+            const uniqueDates = new Set();
+            for (const date of Object.keys(data)) {
+              const entries = Object.values(data[date]);
+              if (entries.length > 0) {
+                uniqueDates.add(date);
+              }
+            }
+    
+            setMarkedDates(Array.from(uniqueDates));
+          }
+        };
+    
+        fetchMarkedDates();
+      
+  }, []);
+    
+
   return (
     <Box sx={{ p: 3 }}>
       <Typography variant="h5" gutterBottom>
@@ -30,14 +61,11 @@ const Dashboard = () => {
 
       <Box sx={{ display: 'flex', gap: 2}}>
         {/* 캘린더 */}
-        <Paper elevation={3}
-        sx={{ width: 500, height:400, p: 2,borderRadius: 2, '& .react-calendar': {width: '100%', height:'100%', fontSize: '1.2rem', },}}>
-          <Calendar 
-            onChange={setValue}
-            value={value}
-            className="custom-calendar"
-          />
-        </Paper>
+        <SharedCalendar
+          value={value}
+          onChange={setValue}
+          markedDates={markedDates}
+        />
 
         {/* 공지사항 */}
         <Box sx={{backgroundColor: '#fff', p: 2, borderRadius: 2,  boxShadow: 3 }}>
@@ -60,6 +88,7 @@ const Dashboard = () => {
           </List>
         </Box>
       </Box>
+      <ScheduleCardBox />
     </Box>
   );
 };

--- a/refacbus_admin/src/pages/ManagerManagement.jsx
+++ b/refacbus_admin/src/pages/ManagerManagement.jsx
@@ -19,6 +19,8 @@ import { realtimeDb } from '../firebase';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import Manager_Schedule from "../components/Manager_Schedule";
+
 
 
 const TabPanel = ({ children, value, index }) => {
@@ -110,7 +112,6 @@ const ManagerManagement = () => {
           }}
         >
           <Tab label="관리자 역할 구분" />
-          <Tab label="주요 기능 접근 제한" />
           <Tab label="일정 등록 및 관리" />
           <Tab label="공지사항 등록 및 관리" />
         </Tabs>
@@ -128,9 +129,10 @@ const ManagerManagement = () => {
         }}
       >
         <TabPanel value={tabIndex} index={0}>관리자 역할 구분</TabPanel>
-        <TabPanel value={tabIndex} index={1}>주요 기능 접근 제한</TabPanel>
-        <TabPanel value={tabIndex} index={2}>일정 등록 및 관리</TabPanel>
-        <TabPanel value={tabIndex} index={3}>
+        <TabPanel value={tabIndex} index={1}>
+          <Manager_Schedule />
+        </TabPanel>
+        <TabPanel value={tabIndex} index={2}>
           <Button
             variant="contained"
             startIcon={<AddIcon />}


### PR DESCRIPTION
##  설명
관리자 일정 등록 및 조회 기능을 구현했습니다.  
등록한 일정은 관리자 대시보드와 스케줄 탭 페이지 모두에서 확인할 수 있으며,  
SharedCalendar에 일정이 등록된 날짜는 색이 칠해져 시각적으로 구분됩니다.

---

##  구현 내용
- `managerSchedules` 경로에 일정 저장 (날짜별로 분류됨)
- 일정 등록 시 필요한 모달(FormControl + TextField) 구성
- 등록된 일정은 박스형 카드(`ScheduleCardBox`)로 날짜별로 표시
- SharedCalendar에서 일정이 있는 날짜에 `highlight` 클래스 부여
- 대시보드에서도 `SharedCalendar`, `공지사항`, `일정 카드` 통합 노출

---

##  관련 변경 사항
- `Manager_Schedule.jsx`: 일정 등록/조회 로직 구현
- `SharedCalendar.jsx`: `markedDates` props로 하이라이트 처리 추가
- `ScheduleCardBox.jsx`: 날짜별 일정 카드 구성 컴포넌트 생성
- `Dashboard.jsx`: 공지사항 + 일정 카드 + 캘린더 통합

---

##  참고 사항
- `react-calendar`의 날짜 포맷을 맞추기 위해 `toISOString().split("T")[0]` 사용
- `Grid` 컴포넌트는 MUI v5 기준으로 마이그레이션 (item, xs, sm 제거)
- 일정 데이터는 `{ date: string, content: Record<string, ScheduleData> }` 형식으로 파싱됨

---

##  테스트 방법
- [x] 관리자 스케줄 탭에서 일정 등록 모달 열기
- [x] 년/월/일/내용 입력 후 저장 → 알림 팝업 확인
- [x] 등록한 날짜에 캘린더 highlight 색상 확인
- [x] 등록된 일정이 박스형 카드로 정상 표시되는지 확인
- [x] 관리자 대시보드에서도 동일한 정보가 보이는지 확인
- [x] 일정이 여러 개 있을 때도 모두 누락 없이 표시되는지 확인
