### PR TITLE
Feature/permission

### DIFF
--- a/refacbus_admin/src/App.jsx
+++ b/refacbus_admin/src/App.jsx
@@ -28,6 +28,7 @@ function App() {
         <Route path="/driver-management" element={<DriverManagement />} />
         <Route path="/manager-management" element={<ManagerManagement />} />
         <Route path="/dashboard" element={<DashBoard />} />
+        <Route path="/Login" element={<Login />} />
       </Routes>
     </BrowserRouter>
   )

--- a/refacbus_admin/src/components/DashBoardSchedule/ScheduleCardBox.jsx
+++ b/refacbus_admin/src/components/DashBoardSchedule/ScheduleCardBox.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from "react";
+import { getDatabase, ref, get } from "firebase/database";
+import { Box, Typography, Paper, Grid } from "@mui/material";
+
+const ScheduleCardBox = () => {
+  const [scheduleList, setScheduleList] = useState([]);
+  
+
+  useEffect(() => {
+    const fetchSchedules = async () => {
+      const db = getDatabase();
+      const scheduleRef = ref(db, "managerSchedules");
+      const snapshot = await get(scheduleRef);
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+        const parsed = Object.entries(data).map(([date, content]) => ({
+          date,
+          content,
+        }));
+        setScheduleList(parsed);
+      }
+    };
+
+    fetchSchedules();
+  }, []);
+
+  return (
+    <Box sx={{ mt: 3, p: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        일정 목록
+      </Typography>
+      <Grid container spacing={2}>
+        {scheduleList.map((item, index) => (
+          <Grid item xs={12} sm={6} md={4} key={index}>
+            <Paper
+              elevation={3}
+              sx={{
+                p: 2,
+                borderRadius: 2,
+                height: 120,
+                backgroundColor: "#f0f4ff",
+              }}
+            >
+              <Typography variant="subtitle1" fontWeight="bold">
+                {item.date}
+              </Typography>
+              {Object.values(item.content).map((schedule, i) => (
+                <Typography key={i} variant="body2" mt={1}>
+                  {schedule.text}
+                </Typography>
+              ))}
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default ScheduleCardBox;

--- a/refacbus_admin/src/components/Driver/DriverListTable.jsx
+++ b/refacbus_admin/src/components/Driver/DriverListTable.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {
+  Table, TableHead, TableBody, TableRow, TableCell, IconButton
+} from '@mui/material';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import DriverWeeklySchedule from './DriverWeeklySchedule';
+
+const DriverListTable = ({
+  users,
+  expandedDriverUid,
+  driverSchedules,
+  coloredSchedule,
+  onTimeClick,
+  onScheduleToggle,
+  onAddClick,
+  onCellClick
+}) => {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>uid</TableCell>
+          <TableCell>아이디</TableCell>
+          <TableCell>이름</TableCell>
+          <TableCell>가입 날짜</TableCell>
+          <TableCell>운행 시간 관리</TableCell>
+          <TableCell>운행 일정 관리</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {users.map((user) => (
+          <React.Fragment key={user.uid}>
+            <TableRow>
+              <TableCell>{user.uid}</TableCell>
+              <TableCell>{user.email}</TableCell>
+              <TableCell>{user.name}</TableCell>
+              <TableCell>{user.joinDate}</TableCell>
+              <TableCell>
+                <IconButton onClick={(e) => onTimeClick(e, user)}>
+                  <AccessTimeIcon />
+                </IconButton>
+              </TableCell>
+              <TableCell>
+                <IconButton onClick={() => onScheduleToggle(user)}>
+                  {expandedDriverUid === user.uid ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                </IconButton>
+              </TableCell>
+            </TableRow>
+
+            {expandedDriverUid === user.uid && (
+              <TableRow>
+                <TableCell colSpan={6}>
+                  <DriverWeeklySchedule
+                    user={user}
+                    scheduleData={driverSchedules[user.uid]}
+                    coloredSchedule={coloredSchedule[user.uid]}
+                    onAddClick={onAddClick}
+                    onCellClick={onCellClick}
+                  />
+                </TableCell>
+              </TableRow>
+            )}
+          </React.Fragment>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default DriverListTable;

--- a/refacbus_admin/src/components/Driver/DriverScheduleDialog.jsx
+++ b/refacbus_admin/src/components/Driver/DriverScheduleDialog.jsx
@@ -1,0 +1,109 @@
+// components/Driver/DriverScheduleDialog.jsx
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Typography, FormControl, InputLabel, Select, MenuItem,
+  Checkbox, ListItemText, Button
+} from '@mui/material';
+
+const DriverScheduleDialog = ({
+  open,
+  onClose,
+  onSave,
+  pinnedRoutes,
+  availableTimes,
+  selectedRoute,
+  selectedTime,
+  selectedDays,
+  duration,
+  onChangeRoute,
+  onChangeTime,
+  onChangeDays,
+  onChangeDuration
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose} PaperProps={{ sx: { width: "600px" } }}>
+      <DialogTitle>스케줄 추가</DialogTitle>
+      <DialogContent>
+        <Typography>노선 스케줄 등록</Typography>
+
+        <FormControl fullWidth sx={{ mt: 2 }}>
+          <InputLabel id="route-select-label">노선 선택</InputLabel>
+          <Select
+            labelId="route-select-label"
+            value={pinnedRoutes.some(route => route.name === selectedRoute) ? selectedRoute : ""}
+            label="노선 선택"
+            onChange={onChangeRoute}
+          >
+            {pinnedRoutes.map((route) => (
+              <MenuItem key={route.id} value={route.name}>
+                {route.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl fullWidth sx={{ mt: 2 }}>
+          <InputLabel id="time-select-label">운행 시간 선택</InputLabel>
+          <Select
+            labelId="time-select-label"
+            value={availableTimes.includes(selectedTime) ? selectedTime : ""}
+            label="운행 시간 선택"
+            onChange={onChangeTime}
+            disabled={!availableTimes.length}
+          >
+            {availableTimes.map((time, index) => (
+              <MenuItem key={index} value={time}>{time}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl fullWidth sx={{ mt: 2 }}>
+          <InputLabel id="day-select-label">운행 요일</InputLabel>
+          <Select
+            labelId="day-select-label"
+            multiple
+            value={selectedDays}
+            label="운행 요일 선택"
+            onChange={onChangeDays}
+            renderValue={(selected) => selected.join(', ')}
+          >
+            {['월', '화', '수', '목', '금'].map((day) => (
+              <MenuItem key={day} value={day}>
+                <Checkbox checked={selectedDays.includes(day)} />
+                <ListItemText primary={day} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl fullWidth sx={{ mt: 2 }}>
+          <InputLabel id="duration-select-label">예상 소요 시간</InputLabel>
+          <Select
+            labelId="duration-select-label"
+            value={duration}
+            label="예상 소요시간 선택"
+            onChange={onChangeDuration}
+          >
+            {[1, 2, 3].map((hour) => (
+              <MenuItem key={hour} value={hour}>{hour}시간</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>취소</Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={onSave}
+          disabled={!selectedRoute || !selectedTime || !duration || !selectedDays.length}
+        >
+          완료
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DriverScheduleDialog;

--- a/refacbus_admin/src/components/Driver/DriverScheduleHeader.jsx
+++ b/refacbus_admin/src/components/Driver/DriverScheduleHeader.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box, Typography, Button } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+
+const DriverScheduleHeader = ({ name, onAddClick }) => {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+      <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+        {name}님의 주간 스케줄표
+      </Typography>
+      <Button
+        variant="contained"
+        size="small"
+        startIcon={<AddIcon />}
+        onClick={onAddClick}
+      >
+        추가
+      </Button>
+    </Box>
+  );
+};
+
+export default DriverScheduleHeader;

--- a/refacbus_admin/src/components/Driver/DriverTableCell.jsx
+++ b/refacbus_admin/src/components/Driver/DriverTableCell.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { TableCell, Typography } from '@mui/material';
+import { getColorByRoute } from '../../utils/colorUnits';
+import { days, timeSlots, getDayIndex } from './constants';
+
+const DriverTableCell = ({
+  day,
+  rowIndex,
+  colIndex,
+  user,
+  scheduleData,
+  isColored,
+  onClick
+}) => {
+  let routeText = '';
+  let isStartCell = false;
+  let bgColor = "inherit";
+
+  if (scheduleData) {
+    Object.values(scheduleData).forEach(({ days, time, duration, route }) => {
+      const startIndex = timeSlots.findIndex((t) => {
+        const [h] = time.split(":").map(Number);
+        const [slotH] = t.split(":").map(Number);
+        return h >= slotH && h < slotH + 1;
+      });
+
+      const col = getDayIndex(day);
+      if (startIndex === -1 || !days.includes(day)) return;
+
+      if (rowIndex >= startIndex && rowIndex < startIndex + duration) {
+        if (rowIndex === startIndex) {
+          routeText = `${route}\n(${time})`;
+          isStartCell = true;
+        }
+        bgColor = getColorByRoute(route);
+      }
+    });
+  }
+
+  const handleClick = () => {
+    if (!isColored || !scheduleData) return;
+
+    const matched = Object.entries(scheduleData).find(([key, { days, time, duration, route }]) => {
+      const startIdx = timeSlots.findIndex((slot) => {
+        const [h] = time.split(":").map(Number);
+        const [slotH] = slot.split(":").map(Number);
+        return h >= slotH && h < slotH + 1;
+      });
+
+      const isMatch =
+        days.includes(day) &&
+        rowIndex >= startIdx &&
+        rowIndex < startIdx + duration;
+
+      return isMatch;
+    });
+
+    if (matched) {
+      const [key, value] = matched;
+      onClick({ ...value, key });
+    }
+  };
+
+  return (
+    <TableCell
+      align="center"
+      sx={{
+        border: "1px solid #ddd",
+        minWidth: "120px",
+        height: 40,
+        backgroundColor: isColored ? bgColor : "inherit",
+        color: isColored ? "#000" : "inherit",
+        whiteSpace: "pre-line",
+        cursor: isColored ? "pointer" : "default",
+        wordBreak: "break-word",
+        textAlign: "center",
+        lineHeight: 1.2,
+        padding: "4px",
+        userSelect: "none"
+      }}
+      onClick={handleClick}
+    >
+      {isStartCell && (
+        <Typography
+          variant="caption"
+          sx={{ fontSize: "0.7rem", fontWeight: 600, cursor: "inherit" }}
+        >
+          {routeText}
+        </Typography>
+      )}
+    </TableCell>
+  );
+};
+
+export default DriverTableCell;

--- a/refacbus_admin/src/components/Driver/DriverWeeklySchedule.jsx
+++ b/refacbus_admin/src/components/Driver/DriverWeeklySchedule.jsx
@@ -1,0 +1,59 @@
+console.log("✅ DriverWeeklySchedule 불러옴!");
+import React from 'react';
+import { Box, Typography, Button, Table, TableHead, TableRow, TableCell, TableBody } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DriverTableCell from './DriverTableCell';
+import DriverScheduleHeader from './DriverScheduleHeader';
+import { days, timeSlots, getDayIndex } from './constants';
+
+
+const DriverWeeklySchedule = ({
+  user,
+  scheduleData,
+  coloredSchedule,
+  onAddClick,
+  onCellClick
+  }) => {
+  return (
+    <Box sx={{ p: 2, backgroundColor: "#f9f9f9", borderRadius: 2, mb: 2 }}>
+      {/* 상단 헤더 */}
+      <DriverScheduleHeader name={user.name} onAddClick={() => onAddClick(user)} />
+
+      {/* 시간표 */}
+      <Table sx={{ tableLayout: 'fixed', width: '100%' }}>
+        <TableHead>
+          <TableRow>
+            <TableCell>시간</TableCell>
+            {days.map((day) => (
+              <TableCell key={day} align="center">{day}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {timeSlots.map((time, rowIndex) => (
+            <TableRow key={time}>
+              <TableCell>{time}</TableCell>
+                {days.map((day, colIndex) => {
+                  const cellKey = `${colIndex}-${rowIndex}`;
+                  return (
+                    <DriverTableCell
+                      key={day}
+                      day={day}
+                      rowIndex={rowIndex}
+                      colIndex={colIndex}
+                      user={user}
+                      scheduleData={scheduleData}
+                      isColored={coloredSchedule?.includes(cellKey)}
+                      onClick={onCellClick}
+                    />
+                  );
+                })}
+              </TableRow>
+            ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+export default DriverWeeklySchedule;

--- a/refacbus_admin/src/components/Driver/DrivingHistoryDialog.jsx
+++ b/refacbus_admin/src/components/Driver/DrivingHistoryDialog.jsx
@@ -1,0 +1,46 @@
+// components/Driver/DrivingHistoryDialog.jsx
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  Table, TableHead, TableBody, TableRow, TableCell,
+  Typography, Button
+} from '@mui/material';
+
+const DrivingHistoryDialog = ({ open, onClose, driverName, historyList }) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>{driverName}님의 운행 이력</DialogTitle>
+      <DialogContent>
+        {historyList.length > 0 ? (
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>노선</TableCell>
+                <TableCell>날짜</TableCell>
+                <TableCell>예정 출발 시간</TableCell>
+                <TableCell>운행 종료 시간</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {historyList.map((record, idx) => (
+                <TableRow key={idx}>
+                  <TableCell>{record.route}</TableCell>
+                  <TableCell>{record.date}</TableCell>
+                  <TableCell>{record.time}</TableCell>
+                  <TableCell>{record.endTime}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <Typography>운행 이력이 없습니다.</Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DrivingHistoryDialog;

--- a/refacbus_admin/src/components/Driver/ResetPasswordDialog.jsx
+++ b/refacbus_admin/src/components/Driver/ResetPasswordDialog.jsx
@@ -1,0 +1,37 @@
+// components/Driver/ResetPasswordDialog.jsx
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Typography, Button
+} from '@mui/material';
+
+const ResetPasswordDialog = ({
+  open,
+  email,
+  onChangeEmail,
+  onSendResetEmail,
+  onClose
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>비밀번호 초기화</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          label="이메일"
+          value={email}
+          onChange={onChangeEmail}
+        />
+        <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+          기본 이메일이 입력되어 있으며, 필요 시 변경 가능합니다.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onSendResetEmail} color="primary">확인</Button>
+        <Button onClick={onClose} color="secondary">취소</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ResetPasswordDialog;

--- a/refacbus_admin/src/components/Driver/constants.js
+++ b/refacbus_admin/src/components/Driver/constants.js
@@ -1,0 +1,12 @@
+// constants.js
+
+export const days = ["월", "화", "수", "목", "금"];
+
+export const timeSlots = [
+  "08:00", "09:00", "10:00", "11:00", "12:00",
+  "16:00", "17:00", "18:00", "19:00",
+];
+
+export const getDayIndex = (day) => {
+  return days.indexOf(day);
+};

--- a/refacbus_admin/src/components/Driver/index.js
+++ b/refacbus_admin/src/components/Driver/index.js
@@ -1,0 +1,5 @@
+export { default as DriverListTable } from './DriverListTable';
+export { default as DriverScheduleDialog } from './DriverScheduleDialog';
+export { default as DrivingHistoryDialog } from './DrivingHistoryDialog';
+export { default as ResetPasswordDialog } from './ResetPasswordDialog';
+

--- a/refacbus_admin/src/components/Manager/Manager_Schedule.jsx
+++ b/refacbus_admin/src/components/Manager/Manager_Schedule.jsx
@@ -17,7 +17,7 @@ import {
 import "react-calendar/dist/Calendar.css";
 import { getDatabase, ref, push, get } from "firebase/database";
 import { getAuth } from "firebase/auth";
-import SharedCalendar from "../components/calendar/SharedCalendar";
+import SharedCalendar from "../calendar/SharedCalendar";
 
 const Manager_Schedule = () => {
   const [value, setValue] = useState(new Date());

--- a/refacbus_admin/src/components/Manager/RoleDialog.jsx
+++ b/refacbus_admin/src/components/Manager/RoleDialog.jsx
@@ -1,0 +1,90 @@
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  FormControlLabel, Checkbox, Box, Button, Typography
+} from '@mui/material';
+import React, { useEffect, useState } from 'react';
+
+const ROLE_STRUCTURE = {
+  "회원 관리": [],
+  "노선/시간 관리": ["노선 추가 및 삭제", "노선 시간대 설정 및 관리", "노선 정류장 설정 및 관리"],
+  "예약 현황/통계": ["날짜별 예약자 목록", "예약 통계", "예약 취소 분석"],
+  "운행 기록 확인": ["기사별 운행 이력", "기사 계정 관리"],
+  "관리자 계정 관리": ["관리자 역할 구분", "일정 등록 및 관리", "공지사항 등록 및 관리"]
+};
+
+const RoleDialog = ({ open, onClose, user, onSave, initialPermissions = {} }) => {
+  const [permissions, setPermissions] = useState({});
+
+  useEffect(() => {
+    setPermissions(initialPermissions);
+  }, [initialPermissions]);
+
+  const handleParentToggle = (parent) => {
+    const children = ROLE_STRUCTURE[parent];
+    const updated = { ...permissions };
+
+    if (children.length === 0) {
+      updated[parent] = !permissions[parent]; 
+    } else {
+      const allChecked = children.every(child => permissions[child]);
+      children.forEach(child => {
+        updated[child] = !allChecked;
+      });
+    }
+
+    setPermissions(updated);
+  };
+
+
+  const handleChildToggle = (child) => {
+    setPermissions(prev => ({
+      ...prev,
+      [child]: !prev[child]
+    }));
+  };
+
+  const isParentChecked = (parent) => {
+    const children = ROLE_STRUCTURE[parent];
+    if (children.length === 0) {
+      return permissions[parent] || false; 
+    }
+    return children.every(child => permissions[child]);
+  };
+
+  const renderSection = (parent, children) => (
+    <Box key={parent} sx={{ mb: 2 }}>
+      <FormControlLabel
+        control={<Checkbox checked={isParentChecked(parent)} onChange={() => handleParentToggle(parent)} />}
+        label={<Typography fontWeight="bold">{parent}</Typography>}
+      />
+      <Box sx={{ pl: 4 }}>
+        {children.map(child => (
+          <FormControlLabel
+            key={child}
+            control={<Checkbox checked={permissions[child] || false} onChange={() => handleChildToggle(child)} />}
+            label={child}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle>관리자 권한 설정 - {user?.name}</DialogTitle>
+      <DialogContent>
+        {Object.entries(ROLE_STRUCTURE).map(([parent, children]) =>
+          renderSection(parent, children)
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>취소</Button>
+        <Button onClick={() => onSave(permissions)} variant="contained" color="primary">
+          저장
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default RoleDialog;

--- a/refacbus_admin/src/components/Manager/permissions.js
+++ b/refacbus_admin/src/components/Manager/permissions.js
@@ -1,0 +1,14 @@
+export const ALL_PERMISSIONS = {
+  "회원 관리": true,
+  "노선 추가/삭제": true,
+  "노선 시간대 설정 및 관리": true,
+  "노선 정류장 설정 및 관리": true,
+  "날짜별 예약자 목록": true,
+  "예약 통계": true,
+  "예약 취소 분석": true,
+  "기사별 운행 이력": true,
+  "기사 계정 관리": true,
+  "관리자 역할 구분": true,
+  "일정 등록 및 관리": true,
+  "공지사항 등록 및 관리": true
+};

--- a/refacbus_admin/src/components/Manager_Schedule.jsx
+++ b/refacbus_admin/src/components/Manager_Schedule.jsx
@@ -1,0 +1,212 @@
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Select,
+  Paper,
+  Typography,
+} from "@mui/material";
+import "react-calendar/dist/Calendar.css";
+import { getDatabase, ref, push, get } from "firebase/database";
+import { getAuth } from "firebase/auth";
+import SharedCalendar from "../components/calendar/SharedCalendar";
+
+const Manager_Schedule = () => {
+  const [value, setValue] = useState(new Date());
+  const [open, setOpen] = useState(false);
+  const [year, setYear] = useState("");
+  const [month, setMonth] = useState("");
+  const [day, setDay] = useState("");
+  const [schedule, setSchedule] = useState("");
+  const [markedDates, setMarkedDates] = useState([]);
+  const [schedules, setSchedules] = useState([]);
+
+  useEffect(() => {
+    const fetchMarkedDates = async () => {
+      const db = getDatabase();
+      const scheduleRef = ref(db, "managerSchedules");
+      const snapshot = await get(scheduleRef);
+
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+
+        const uniqueDates = new Set();
+        const scheduleList = [];
+
+        for (const date of Object.keys(data)) {
+          const entries = Object.values(data[date]);
+          if (entries.length > 0) {
+            uniqueDates.add(date);
+          }
+          entries.forEach((item) => {
+            scheduleList.push({
+              date,
+              text: item.text || "",
+            });
+          });
+        }
+
+        setMarkedDates(Array.from(uniqueDates));
+        setSchedules(scheduleList);
+      }
+    };
+
+    fetchMarkedDates();
+  }, []);
+
+  const handleAddClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleSave = () => {
+    if (!year || !month || !day || !schedule.trim()) {
+      alert("모든 값을 입력해주세요!");
+      return;
+    }
+
+    const db = getDatabase();
+    const auth = getAuth();
+    const uid = auth.currentUser?.uid;
+
+    if (!uid) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
+
+    const dateKey = `${year}-${month}-${day}`;
+
+    const scheduleData = {
+      date: dateKey,
+      text: schedule.trim(),
+      createdAt: new Date().toISOString(),
+      uid: uid,
+    };
+
+    push(ref(db, `managerSchedules/${dateKey}`), scheduleData)
+      .then(() => {
+        alert("일정이 저장되었습니다!");
+        setOpen(false);
+        setYear("");
+        setMonth("");
+        setDay("");
+        setSchedule("");
+        setMarkedDates((prev) => [...new Set([...prev, dateKey])]);
+        setSchedules((prev) => [...prev, { date: dateKey, text: schedule.trim() }]);
+      })
+      .catch((error) => {
+        console.error("일정 저장 오류:", error);
+        alert("일정 저장에 실패했습니다.");
+      });
+  };
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      {/* 캘린더 + 일정 목록 + 버튼 */}
+      <Box sx={{ display: "flex", gap: 2, alignItems: "flex-start" }}>
+        <SharedCalendar
+          value={value}
+          onChange={setValue}
+          markedDates={markedDates}
+        />
+
+        {/* 일정 목록 */}
+        <Box
+          sx={{
+            minWidth: "200px",
+            p: 2,
+            border: "1px solid #ccc",
+            borderRadius: 2,
+            backgroundColor: "#f9f9f9",
+          }}
+        >
+          <Typography variant="h6" gutterBottom>
+            📋 등록된 일정
+          </Typography>
+          {schedules.map((s, i) => (
+            <Box key={i} sx={{ mb: 1 }}>
+              <strong>{s.date}</strong>
+              <br />
+              {s.text}
+            </Box>
+          ))}
+        </Box>
+
+        {/* 일정 추가 버튼 */}
+        <Box sx={{ alignSelf: "center" }}>
+          <Button variant="contained" onClick={handleAddClick}>
+            일정 추가
+          </Button>
+        </Box>
+      </Box>
+
+      {/* 일정 추가 모달 */}
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>📅 일정 등록</DialogTitle>
+        <DialogContent
+          sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}
+        >
+          <Box sx={{ display: "flex", gap: 2 }}>
+            <FormControl sx={{ width: 100 }}>
+              <InputLabel>년도</InputLabel>
+              <Select value={year} onChange={(e) => setYear(e.target.value)}>
+                <MenuItem value="2025">2025</MenuItem>
+                <MenuItem value="2024">2024</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl sx={{ width: 100 }}>
+              <InputLabel>월</InputLabel>
+              <Select value={month} onChange={(e) => setMonth(e.target.value)}>
+                {Array.from({ length: 12 }, (_, i) => (
+                  <MenuItem key={i + 1} value={String(i + 1).padStart(2, "0")}>
+                    {i + 1}월
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl sx={{ width: 100 }}>
+              <InputLabel>일</InputLabel>
+              <Select value={day} onChange={(e) => setDay(e.target.value)}>
+                {Array.from({ length: 31 }, (_, i) => (
+                  <MenuItem key={i + 1} value={String(i + 1).padStart(2, "0")}>
+                    {i + 1}일
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+
+          <TextField
+            label="일정 내용"
+            variant="outlined"
+            fullWidth
+            multiline
+            rows={3}
+            value={schedule}
+            onChange={(e) => setSchedule(e.target.value)}
+          />
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={handleClose}>취소</Button>
+          <Button onClick={handleSave} variant="contained">
+            저장
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default Manager_Schedule;

--- a/refacbus_admin/src/components/Notice/NoticeFormDialog.jsx
+++ b/refacbus_admin/src/components/Notice/NoticeFormDialog.jsx
@@ -1,0 +1,60 @@
+// components/NoticeFormDialog.jsx
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  TextField,
+  IconButton,
+  Button,
+  Typography,
+  Box
+} from "@mui/material";
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+
+const NoticeFormDialog = ({
+  open,
+  title,
+  setTitle,
+  url,
+  setUrl,
+  isPinned,
+  setIsPinned,
+  onSubmit,
+  onCancel
+}) => {
+  return (
+    <Dialog open={open} onClose={onCancel}>
+      <DialogTitle>공지사항 등록</DialogTitle>
+      <DialogContent>
+        <TextField
+          label="제목"
+          fullWidth
+          margin="normal"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <TextField
+          label="URL"
+          fullWidth
+          margin="normal"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
+          <IconButton onClick={() => setIsPinned(prev => !prev)}>
+            {isPinned ? <StarIcon color="primary" /> : <StarBorderIcon />}
+          </IconButton>
+          <Typography>{isPinned ? '대시보드에 노출됨' : '공지사항에 등록'}</Typography>
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <Button variant="contained" onClick={onSubmit}>등록</Button>
+          <Button onClick={onCancel} sx={{ ml: 1 }}>취소</Button>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default NoticeFormDialog;

--- a/refacbus_admin/src/components/Notice/NoticeList.jsx
+++ b/refacbus_admin/src/components/Notice/NoticeList.jsx
@@ -1,0 +1,35 @@
+// components/NoticeList.jsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItemButton,
+  ListItemText
+} from "@mui/material";
+
+const NoticeList = ({ notices = [] }) => {
+  return (
+    <Box sx={{ backgroundColor: '#fff', p: 2, borderRadius: 2, boxShadow: 3 }}>
+      <Typography variant="h6" gutterBottom>
+        공지사항
+      </Typography>
+      <List>
+        {notices.map((notice, index) => (
+          <ListItemButton
+            key={index}
+            component="a"
+            href={notice.url}
+            target="_blank"
+          >
+            <ListItemText
+              primary={`${notice.title} (${new Date(notice.date).toLocaleDateString('ko-KR')})`}
+            />
+          </ListItemButton>
+        ))}
+      </List>
+    </Box>
+  );
+};
+
+export default NoticeList;

--- a/refacbus_admin/src/components/PlaceTime/RouteAddDialog.jsx
+++ b/refacbus_admin/src/components/PlaceTime/RouteAddDialog.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Button, FormControlLabel, Checkbox
+} from '@mui/material';
+
+const RouteAddDialog = ({
+  open,
+  routeName,
+  isPinned,
+  onChangeName,
+  onChangePinned,
+  onClose,
+  onSubmit
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>노선 추가</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          fullWidth
+          label="노선 이름"
+          value={routeName}
+          onChange={onChangeName}
+          sx={{ mt: 1 }}
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={isPinned}
+              onChange={onChangePinned}
+            />
+          }
+          label="고정 여부"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>취소</Button>
+        <Button onClick={onSubmit} variant="contained">등록</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default RouteAddDialog;

--- a/refacbus_admin/src/components/PlaceTime/RouteCard.jsx
+++ b/refacbus_admin/src/components/PlaceTime/RouteCard.jsx
@@ -1,0 +1,42 @@
+// components/RouteCard.jsx
+import React from "react";
+import { Box, Typography } from "@mui/material";
+
+const RouteCard = ({
+  label = '',
+  items = {},
+  onClickItem = () => {},
+  emptyMessage = '등록된 항목이 없습니다.',
+  color = '#e3f2fd'
+}) => {
+  return (
+    <Box>
+      <Typography sx={{ mb: 1 }}>{label}</Typography>
+      {Object.keys(items).length > 0 ? (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          {Object.entries(items).map(([key, value]) => (
+            <Box
+              key={key}
+              onClick={() => onClickItem(key, value)}
+              sx={{
+                cursor: 'pointer',
+                width: '19%',
+                backgroundColor: color,
+                padding: '8px',
+                borderRadius: '4px',
+                textAlign: 'center',
+                boxShadow: 1,
+              }}
+            >
+              {value}
+            </Box>
+          ))}
+        </Box>
+      ) : (
+        <Typography color="text.secondary">{emptyMessage}</Typography>
+      )}
+    </Box>
+  );
+};
+
+export default RouteCard;

--- a/refacbus_admin/src/components/PlaceTime/RouteListTable.jsx
+++ b/refacbus_admin/src/components/PlaceTime/RouteListTable.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  TableContainer, Table, TableHead, TableRow,
+  TableCell, TableBody, Paper, IconButton
+} from '@mui/material';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+
+const RouteListTable = ({
+  routeList,
+  onClickRoute,
+  onTogglePinned
+}) => {
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell style={{ width: "50%" }}>노선</TableCell>
+            <TableCell style={{ width: "40%" }}>등록 날짜</TableCell>
+            <TableCell style={{ width: "10%" }}>고정</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {routeList.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell>
+                <span
+                  style={{ cursor: 'pointer', textDecoration: 'underline' }}
+                  onClick={() => onClickRoute(item)}
+                >
+                  {item.name}
+                </span>
+              </TableCell>
+              <TableCell>{new Date(item.date).toLocaleDateString()}</TableCell>
+              <TableCell>
+                <IconButton onClick={() => onTogglePinned(item.id, item.isPinned)}>
+                  {item.isPinned ? (
+                    <StarIcon color="warning" />
+                  ) : (
+                    <StarBorderIcon />
+                  )}
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default RouteListTable;

--- a/refacbus_admin/src/components/PlaceTime/StopAddDialog.jsx
+++ b/refacbus_admin/src/components/PlaceTime/StopAddDialog.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Button
+} from '@mui/material';
+
+const StopAddDialog = ({
+  open,
+  value,
+  onChange,
+  onSubmit,
+  onClose
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>정류장 추가</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          label="정류장 이름"
+          value={value}
+          onChange={onChange}
+          autoFocus
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onSubmit} variant="contained">확인</Button>
+        <Button onClick={onClose} color="secondary">취소</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default StopAddDialog;

--- a/refacbus_admin/src/components/PlaceTime/StopEditDialog.jsx
+++ b/refacbus_admin/src/components/PlaceTime/StopEditDialog.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Button
+} from '@mui/material';
+
+const StopEditDialog = ({
+  open,
+  value,
+  onChange,
+  onUpdate,
+  onDelete,
+  onClose
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>정류장 수정 / 삭제</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          label="정류장 이름"
+          value={value}
+          onChange={onChange}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onUpdate} color="primary">수정</Button>
+        <Button onClick={onDelete} color="error">삭제</Button>
+        <Button onClick={onClose} color="secondary">취소</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default StopEditDialog;

--- a/refacbus_admin/src/components/PlaceTime/TimeAddDialog.jsx
+++ b/refacbus_admin/src/components/PlaceTime/TimeAddDialog.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Button
+} from '@mui/material';
+
+const TimeAddDialog = ({
+  open,
+  value,
+  onChange,
+  onClose,
+  onSubmit
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>시간대 추가</DialogTitle>
+      <DialogContent>
+        <TextField
+          label="시간 입력"
+          multiline
+          fullWidth
+          value={value}
+          onChange={onChange}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onSubmit} color="primary">확인</Button>
+        <Button onClick={onClose} color="secondary">취소</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default TimeAddDialog;

--- a/refacbus_admin/src/components/PlaceTime/TimeEditDialog.jsx
+++ b/refacbus_admin/src/components/PlaceTime/TimeEditDialog.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Button
+} from '@mui/material';
+
+const TimeEditDialog = ({
+  open,
+  value,
+  onChange,
+  onUpdate,
+  onDelete,
+  onClose
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>시간 수정</DialogTitle>
+      <DialogContent>
+        <TextField
+          fullWidth
+          label="시간"
+          value={value}
+          onChange={onChange}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onUpdate} color="primary">수정</Button>
+        <Button onClick={onDelete} color="error">삭제</Button>
+        <Button onClick={onClose} color="secondary">취소</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default TimeEditDialog;

--- a/refacbus_admin/src/components/PlaceTime/TimeStopTable.jsx
+++ b/refacbus_admin/src/components/PlaceTime/TimeStopTable.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import {
+  Table, TableHead, TableRow, TableCell, TableBody, IconButton, Typography
+} from "@mui/material";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import RouteCard from "./RouteCard"; // 경로 카드 공통 컴포넌트
+
+const RouteExpandableTable = ({
+  filteredRoutes,
+  openRouteId,
+  setOpenRouteId,
+  itemKey,           // 'times' or 'stops'
+  itemLabel,         // '시간대' or '정류장'
+  onAddClick,
+  onItemClick,
+  setEditText,
+  setOpenEditDialog,
+  setSelectedInfo,
+  cardColor,
+  getCountLabel,     // (count) => string
+}) => {
+  const handleToggle = (routeId) => {
+    setOpenRouteId(openRouteId === routeId ? null : routeId);
+  };
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell style={{ width: "40%" }}>노선명</TableCell>
+          <TableCell style={{ width: "20%" }}>{itemLabel} 수</TableCell>
+          <TableCell style={{ width: "20%" }}>{itemLabel} 추가</TableCell>
+          <TableCell style={{ width: "20%" }}>{itemLabel} 목록</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {filteredRoutes.map((route) => {
+          const items = route[itemKey];
+          const itemCount = items ? Object.keys(items).length : 0;
+
+          return (
+            <React.Fragment key={route.uid}>
+              <TableRow>
+                <TableCell>{route.name}</TableCell>
+                <TableCell>{getCountLabel(itemCount)}</TableCell>
+                <TableCell>
+                  <IconButton onClick={() => onAddClick(route)}>
+                    <AccessTimeIcon />
+                  </IconButton>
+                </TableCell>
+                <TableCell>
+                  <IconButton onClick={() => handleToggle(route.uid)}>
+                    {openRouteId === route.uid ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+
+              {openRouteId === route.uid && (
+                <TableRow>
+                  <TableCell colSpan={4}>
+                    <Typography sx={{ mb: 1 }}>🚌 {itemLabel} 목록</Typography>
+                    <RouteCard
+                      items={items}
+                      onClickItem={(itemId, value) => {
+                        setSelectedInfo({ routeId: route.uid, itemId, value });
+                        setEditText(value);
+                        setOpenEditDialog(true);
+                      }}
+                      color={cardColor}
+                      emptyMessage={`등록된 ${itemLabel}이 없습니다`}
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default RouteExpandableTable;

--- a/refacbus_admin/src/components/Reservation/DateSelector.jsx
+++ b/refacbus_admin/src/components/Reservation/DateSelector.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+
+const DateSelector = ({
+  year,
+  month,
+  day,
+  onYearChange,
+  onMonthChange,
+  onDayChange,
+  allowEmpty = false,
+}) => {
+  const years = ['2023', '2024', '2025'];
+  const months = Array.from({ length: 12 }, (_, i) => String(i + 1).padStart(2, '0'));
+  const days = Array.from({ length: 31 }, (_, i) => String(i + 1).padStart(2, '0'));
+
+  return (
+    <>
+      <FormControl sx={{ width: 150 }}>
+        <InputLabel>년도</InputLabel>
+        <Select value={year} onChange={onYearChange}>
+          {allowEmpty && <MenuItem value="">전체</MenuItem>}
+          {years.map((y) => (
+            <MenuItem key={y} value={y}>{y}</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl sx={{ width: 150 }}>
+        <InputLabel>월</InputLabel>
+        <Select value={month} onChange={onMonthChange}>
+          {allowEmpty && <MenuItem value="">전체</MenuItem>}
+          {months.map((m) => (
+            <MenuItem key={m} value={m}>{Number(m)}월</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl sx={{ width: 150 }}>
+        <InputLabel>일</InputLabel>
+        <Select value={day} onChange={onDayChange}>
+          {allowEmpty && <MenuItem value="">전체</MenuItem>}
+          {days.map((d) => (
+            <MenuItem key={d} value={d}>{Number(d)}일</MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </>
+  );
+};
+
+export default DateSelector;

--- a/refacbus_admin/src/components/Reservation/DeleteStatFilterBar.jsx
+++ b/refacbus_admin/src/components/Reservation/DeleteStatFilterBar.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button
+} from '@mui/material';
+import DateSelector from './DateSelector';
+
+const DeleteStatFilterBar = ({
+  deleteType,
+  onDeleteTypeChange,
+  deleteYear,
+  deleteMonth,
+  deleteDay,
+  onYearChange,
+  onMonthChange,
+  onDayChange,
+  selectedRoute,
+  onRouteChange,
+  routeList,
+  onSearchClick
+}) => {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 5 }}>
+      {/* 통계 유형 선택 */}
+      <FormControl sx={{ width: 200 }}>
+        <InputLabel>통계 유형</InputLabel>
+        <Select value={deleteType} onChange={onDeleteTypeChange}>
+          <MenuItem value="route">날짜별 취소 노선 수</MenuItem>
+          <MenuItem value="time">노선별 취소 시간대</MenuItem>
+          <MenuItem value="routeTotal">전체 취소 노선 수</MenuItem>
+          <MenuItem value="reason">전체 취소 사유</MenuItem>
+        </Select>
+      </FormControl>
+
+      {/* 날짜 필터 (route 유형일 때만) */}
+      {deleteType === 'route' && (
+        <DateSelector
+          year={deleteYear}
+          month={deleteMonth}
+          day={deleteDay}
+          onYearChange={onYearChange}
+          onMonthChange={onMonthChange}
+          onDayChange={onDayChange}
+          allowEmpty={true}
+        />
+      )}
+
+      {/* 노선 필터 (time 유형일 때만) */}
+      {deleteType === 'time' && (
+        <FormControl sx={{ width: 200 }}>
+          <InputLabel>노선 선택</InputLabel>
+          <Select value={selectedRoute} onChange={(e) => onRouteChange(e.target.value)}>
+            {routeList.map((route) => (
+              <MenuItem key={route} value={route}>{route}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
+      {/* 조회 버튼 */}
+      <Button variant="contained" onClick={onSearchClick}>조회</Button>
+    </Box>
+  );
+};
+
+export default DeleteStatFilterBar;

--- a/refacbus_admin/src/components/Reservation/ReservationListTable.jsx
+++ b/refacbus_admin/src/components/Reservation/ReservationListTable.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Box, Typography, Paper } from '@mui/material';
+
+const ReservationListTable = ({ data = [] }) => {
+  return (
+    <Paper
+      elevation={2}
+      sx={{
+        backgroundColor: '#fff',
+        padding: 2,
+        mt: 2,
+        borderRadius: 2,
+      }}
+    >
+      <Box sx={{ display: 'flex', mb: 1 }}>
+        <Typography sx={{ width: 200, fontWeight: 'bold' }}>이메일</Typography>
+        <Typography sx={{ width: 200, fontWeight: 'bold' }}>이름</Typography>
+        <Typography sx={{ width: 200, fontWeight: 'bold' }}>노선</Typography>
+        <Typography sx={{ width: 200, fontWeight: 'bold' }}>출발 시간</Typography>
+        <Typography sx={{ width: 200, fontWeight: 'bold' }}>취소 여부</Typography>
+      </Box>
+
+      {data.length > 0 ? (
+        data.map((item, index) => (
+          <Box
+            key={index}
+            sx={{
+              display: 'flex',
+              py: 1,
+              borderBottom: '1px solid #eee',
+            }}
+          >
+            <Typography sx={{ width: 200 }}>{item.email}</Typography>
+            <Typography sx={{ width: 200 }}>{item.name}</Typography>
+            <Typography sx={{ width: 200 }}>{item.route}</Typography>
+            <Typography sx={{ width: 200 }}>{item.time}</Typography>
+            <Typography sx={{ width: 200 }}>
+              {item.canceled ? '취소됨' : '예약 중'}
+            </Typography>
+          </Box>
+        ))
+      ) : (
+        <Typography sx={{ py: 2, textAlign: 'center' }}>
+          조회된 예약이 없습니다.
+        </Typography>
+      )}
+    </Paper>
+  );
+};
+
+export default ReservationListTable;

--- a/refacbus_admin/src/components/Reservation/StatBarChart.jsx
+++ b/refacbus_admin/src/components/Reservation/StatBarChart.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip
+} from 'recharts';
+
+const StatBarChart = ({
+  data = [],
+  dataKey = 'count',
+  color = '#FABE00',
+  barSize = 50,
+}) => {
+  return (
+    <ResponsiveContainer width="100%" height={350}>
+      <BarChart data={data}>
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey={dataKey} fill={color} barSize={barSize} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default StatBarChart;

--- a/refacbus_admin/src/components/Reservation/StatFilterBar.jsx
+++ b/refacbus_admin/src/components/Reservation/StatFilterBar.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button
+} from '@mui/material';
+import DateSelector from './DateSelector';
+
+const StatFilterBar = ({
+  statType,
+  onTypeChange,
+  chartYear,
+  chartMonth,
+  chartDay,
+  onYearChange,
+  onMonthChange,
+  onDayChange,
+  selectedRoute,
+  onRouteChange,
+  routeList,
+  onSearchClick
+}) => {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 5 }}>
+      {/* 통계 유형 선택 */}
+      <FormControl sx={{ width: 200 }}>
+        <InputLabel>통계 유형</InputLabel>
+        <Select value={statType} onChange={onTypeChange}>
+          <MenuItem value="route">날짜별 노선별 예약 수</MenuItem>
+          <MenuItem value="station">노선별 정류장 예약 수</MenuItem>
+          <MenuItem value="time">노선별 시간대 예약 수</MenuItem>
+          <MenuItem value="routeTotal">전체 노선 누적 예약 수</MenuItem>
+        </Select>
+      </FormControl>
+
+      {/* 날짜 필터 (route 유형일 때만 표시) */}
+      {statType === 'route' && (
+        <DateSelector
+          year={chartYear}
+          month={chartMonth}
+          day={chartDay}
+          onYearChange={onYearChange}
+          onMonthChange={onMonthChange}
+          onDayChange={onDayChange}
+          allowEmpty={true}
+        />
+      )}
+
+      {/* 노선 필터 (station / time 유형일 때만 표시) */}
+      {(statType === 'station' || statType === 'time') && (
+        <FormControl sx={{ width: 200 }}>
+          <InputLabel>노선 선택</InputLabel>
+          <Select value={selectedRoute} onChange={(e) => onRouteChange(e.target.value)}>
+            {routeList.map((route) => (
+              <MenuItem key={route} value={route}>{route}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+
+      {/* 조회 버튼 */}
+      <Button variant="contained" onClick={onSearchClick}>조회</Button>
+    </Box>
+  );
+};
+
+export default StatFilterBar;

--- a/refacbus_admin/src/components/Sidebar.jsx
+++ b/refacbus_admin/src/components/Sidebar.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -16,10 +15,25 @@ import ReservationsIcon from '@mui/icons-material/DirectionsBus';
 import DriveNoteIcon from '@mui/icons-material/EventNote';
 import ManagerIcon from '@mui/icons-material/AdminPanelSettings';
 import LogoutIcon from '@mui/icons-material/Logout';
-
+import { signOut } from "firebase/auth";
+import { auth } from "../firebase";
+import { useNavigate } from "react-router-dom"; 
 const drawerWidth = 240;
 
 const Sidebar = ({ onMenuSelect }) => {
+
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    try {
+      await signOut(auth);
+      navigate("/Login"); // 로그인 페이지 경로
+    } catch (error) {
+      console.error("로그아웃 실패:", error);
+      alert("로그아웃에 실패했습니다.");
+    }
+  };
+
   return (
     <Drawer
       sx={{
@@ -71,7 +85,7 @@ const Sidebar = ({ onMenuSelect }) => {
       </List>
       <Divider sx={{ backgroundColor: '#ffffff33' }} />
       <List>
-        <ListItemButton>
+        <ListItemButton onClick={handleLogout}>
           <ListItemIcon sx={{ color: 'white' }}><LogoutIcon /></ListItemIcon>
           <ListItemText primary="로그아웃" />
         </ListItemButton>

--- a/refacbus_admin/src/components/User/MemoDialog.jsx
+++ b/refacbus_admin/src/components/User/MemoDialog.jsx
@@ -1,0 +1,53 @@
+// components/MemoDialog.jsx
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Checkbox,
+  FormControlLabel,
+  Button
+} from "@mui/material";
+
+const MemoDialog = ({
+  open,
+  memoText,
+  setMemoText,
+  isWarning,
+  setIsWarning,
+  isBan,
+  setIsBan,
+  onConfirm,
+  onCancel
+}) => {
+  return (
+    <Dialog open={open} onClose={onCancel}>
+      <DialogTitle>관리자 메모</DialogTitle>
+      <DialogContent>
+        <TextField
+          label="메모 내용"
+          multiline
+          fullWidth
+          value={memoText}
+          onChange={(e) => setMemoText(e.target.value)}
+        />
+        <FormControlLabel
+          control={<Checkbox checked={isWarning} onChange={(e) => setIsWarning(e.target.checked)} />}
+          label="경고 부여"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={isBan} onChange={(e) => setIsBan(e.target.checked)} />}
+          label="계정 정지"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onConfirm} color="primary">확인</Button>
+        <Button onClick={onCancel} color="secondary">취소</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default MemoDialog;

--- a/refacbus_admin/src/components/User/MemoHistoryDialog.jsx
+++ b/refacbus_admin/src/components/User/MemoHistoryDialog.jsx
@@ -1,0 +1,58 @@
+// components/MemoHistoryDialog.jsx
+import React from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Paper
+} from "@mui/material";
+
+const MemoHistoryDialog = ({
+  open,
+  onClose,
+  memoFilter,
+  setMemoFilter,
+  memoList
+}) => {
+  const filtered = memoList.filter(memo =>
+    memoFilter === "all" ? true : memo.type === memoFilter
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>📋 메모 이력</DialogTitle>
+      <Box sx={{ display: 'flex', gap: 1, mb: 2, px: 3 }}>
+        <Button variant={memoFilter === "all" ? "contained" : "outlined"} onClick={() => setMemoFilter("all")}>전체</Button>
+        <Button variant={memoFilter === "warning" ? "contained" : "outlined"} onClick={() => setMemoFilter("warning")}>경고</Button>
+        <Button variant={memoFilter === "ban" ? "contained" : "outlined"} onClick={() => setMemoFilter("ban")}>정지</Button>
+      </Box>
+      <DialogContent>
+        {filtered.length === 0 ? (
+          <Typography>메모 이력이 없습니다.</Typography>
+        ) : (
+          <Box>
+            {filtered.map((memo, index) => (
+              <Box key={index}>
+                <Typography variant="body2" sx={{ mb: 1 }}>
+                  {memo.timestamp} / {memo.writer}
+                </Typography>
+                <Paper sx={{ p: 1, mb: 2 }}>
+                  <Typography>{memo.text}</Typography>
+                </Paper>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>닫기</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default MemoHistoryDialog;

--- a/refacbus_admin/src/components/User/PasswordResetDialog.jsx
+++ b/refacbus_admin/src/components/User/PasswordResetDialog.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Typography, Button
+} from '@mui/material';
+
+const PasswordResetDialog = ({
+  open,
+  email,
+  setEmail,
+  onConfirm,
+  onClose
+}) => (
+  <Dialog open={open} onClose={onClose}>
+    <DialogTitle>비밀번호 초기화</DialogTitle>
+    <DialogContent>
+      <TextField
+        fullWidth
+        label="이메일"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
+        기본 이메일이 입력되어 있으며, 필요 시 변경 가능합니다.
+      </Typography>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onConfirm} color="primary">확인</Button>
+      <Button onClick={onClose} color="secondary">취소</Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export default PasswordResetDialog;

--- a/refacbus_admin/src/components/User/UserEditDialog.jsx
+++ b/refacbus_admin/src/components/User/UserEditDialog.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  Dialog, DialogTitle, DialogContent, DialogActions,
+  TextField, Button
+} from '@mui/material';
+
+const UserEditDialog = ({
+  open,
+  onClose,
+  onConfirm,
+  email,
+  name,
+  setEmail,
+  setName
+}) => (
+  <Dialog open={open} onClose={onClose}>
+    <DialogTitle>회원 정보 수정</DialogTitle>
+    <DialogContent>
+      <TextField
+        margin="dense"
+        label="이메일"
+        fullWidth
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <TextField
+        margin="dense"
+        label="이름"
+        fullWidth
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose}>취소</Button>
+      <Button onClick={onConfirm} color="primary">확인</Button>
+    </DialogActions>
+  </Dialog>
+);
+
+export default UserEditDialog;

--- a/refacbus_admin/src/components/User/UserTable.jsx
+++ b/refacbus_admin/src/components/User/UserTable.jsx
@@ -23,7 +23,8 @@ const UserTable = ({
   onUnban,
   onReset,
   onEdit,
-  onMemoHistory
+  onMemoHistory,
+  onRoleClick 
 }) => {
   return (
     <Table>
@@ -45,7 +46,7 @@ const UserTable = ({
             <TableCell>{user.uid}</TableCell>
             <TableCell>{user.email}</TableCell>
             <TableCell>{user.name}</TableCell>
-            <TableCell>{user.joinDate}</TableCell>
+            <TableCell>{user.joinDate ? user.joinDate.split("T")[0] : "-"}</TableCell>
             <TableCell>{user.warningCount ?? 0}</TableCell>
             <TableCell>{user.isBanned ? "정지됨" : "X"}</TableCell>
 
@@ -62,6 +63,9 @@ const UserTable = ({
                 <MenuItem onClick={() => { onReset(user); onMenuClose(); }}>비밀번호 초기화</MenuItem>
                 <MenuItem onClick={() => { onEdit(user); onMenuClose(); }}>회원 수정</MenuItem>
                 <MenuItem onClick={() => { onMemoHistory(user); onMenuClose(); }}>메모 보기</MenuItem>
+                {type === "admin" && user.name !== "박정원" && (
+                  <MenuItem onClick={() => { onRoleClick(user); onMenuClose(); }}>권한 설정</MenuItem>
+                )}
               </Menu>
             </TableCell>
 

--- a/refacbus_admin/src/components/User/UserTable.jsx
+++ b/refacbus_admin/src/components/User/UserTable.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  IconButton,
+  Menu,
+  MenuItem
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import EditNoteIcon from "@mui/icons-material/EditNote";
+
+const UserTable = ({
+  users,
+  type = "user",
+  onMemoClick,
+  onMenuClick,
+  anchorEl,
+  anchorUserId,
+  onMenuClose,
+  onUnban,
+  onReset,
+  onEdit,
+  onMemoHistory
+}) => {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>uid</TableCell>
+          <TableCell>아이디</TableCell>
+          <TableCell>이름</TableCell>
+          <TableCell>가입 날짜</TableCell>
+          <TableCell>경고 횟수</TableCell>
+          <TableCell>정지</TableCell>
+          <TableCell>작업</TableCell>
+          <TableCell>메모</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {users.map((user) => (
+          <TableRow key={user.uid}>
+            <TableCell>{user.uid}</TableCell>
+            <TableCell>{user.email}</TableCell>
+            <TableCell>{user.name}</TableCell>
+            <TableCell>{user.joinDate}</TableCell>
+            <TableCell>{user.warningCount ?? 0}</TableCell>
+            <TableCell>{user.isBanned ? "정지됨" : "X"}</TableCell>
+
+            <TableCell>
+              <IconButton onClick={(e) => onMenuClick(e, user)}>
+                <MoreVertIcon />
+              </IconButton>
+              <Menu
+                anchorEl={anchorEl}
+                open={anchorUserId === user.uid}
+                onClose={onMenuClose}
+              >
+                <MenuItem onClick={() => onUnban(user.uid)}>정지 해제</MenuItem>
+                <MenuItem onClick={() => { onReset(user); onMenuClose(); }}>비밀번호 초기화</MenuItem>
+                <MenuItem onClick={() => { onEdit(user); onMenuClose(); }}>회원 수정</MenuItem>
+                <MenuItem onClick={() => { onMemoHistory(user); onMenuClose(); }}>메모 보기</MenuItem>
+              </Menu>
+            </TableCell>
+
+            <TableCell>
+              <IconButton onClick={() => onMemoClick(user)}>
+                <EditNoteIcon />
+              </IconButton>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default UserTable;

--- a/refacbus_admin/src/components/User/index.js
+++ b/refacbus_admin/src/components/User/index.js
@@ -1,0 +1,3 @@
+export { default as UserTable } from './UserTable';
+export { default as MemoDialog } from './MemoDialog';
+export { default as MemoHistoryDialog } from './MemoHistoryDialog';

--- a/refacbus_admin/src/components/calendar/SharedCalendar.css
+++ b/refacbus_admin/src/components/calendar/SharedCalendar.css
@@ -1,0 +1,12 @@
+.highlight {
+  background-color: #FABE00; /* 파란 배경 */
+  color: black;
+  border-radius: 50%;
+  font-weight: bold;
+}
+.react-calendar__tile.highlight {
+  background: #90caf9 !important;
+  color: white;
+  border-radius: 50%;
+  font-weight: bold;
+}

--- a/refacbus_admin/src/components/calendar/SharedCalendar.jsx
+++ b/refacbus_admin/src/components/calendar/SharedCalendar.jsx
@@ -1,0 +1,49 @@
+// components/SharedCalendar.jsx
+import React from "react";
+import Calendar from "react-calendar";
+import Paper from "@mui/material/Paper";
+import "./SharedCalendar.css"; 
+
+
+const SharedCalendar = ({ value, onChange, markedDates = [] }) => {
+  const tileClassName = ({ date, view }) => {
+    if (view === "month") {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      const dateStr = `${year}-${month}-${day}`;
+
+      if (markedDates.includes(dateStr)) {
+        return "highlight";
+      }
+    }
+    return null;
+  };
+
+
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        width: 500,
+        height: 400,
+        p: 2,
+        borderRadius: 2,
+        "& .react-calendar": {
+          width: "100%",
+          height: "100%",
+          fontSize: "1.2rem",
+        },
+      }}
+    >
+      <Calendar
+        onChange={onChange}
+        value={value}
+        className="custom-calendar"
+        tileClassName={tileClassName}
+      />
+    </Paper>
+  );
+};
+
+export default SharedCalendar;

--- a/refacbus_admin/src/components/common/SearchBar.jsx
+++ b/refacbus_admin/src/components/common/SearchBar.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { TextField } from '@mui/material';
+
+const SearchBar = ({ value, onChange, placeholder = '검색어 입력', width = 500 }) => {
+  return (
+    <TextField
+      label={placeholder}
+      variant="outlined"
+      size="small"
+      value={value}
+      onChange={onChange}
+      sx={{ width, mb: 2 }}
+    />
+  );
+};
+
+export default SearchBar;

--- a/refacbus_admin/src/components/common/TabPanel.jsx
+++ b/refacbus_admin/src/components/common/TabPanel.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Box } from "@mui/material";
+
+const TabPanel = ({ children, value, index }) => {
+  return (
+    <div hidden={value !== index}>
+      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+    </div>
+  );
+};
+
+export default TabPanel;

--- a/refacbus_admin/src/components/common/TabbedContainer.jsx
+++ b/refacbus_admin/src/components/common/TabbedContainer.jsx
@@ -1,0 +1,32 @@
+// components/common/TabbedContainer.jsx
+import React from "react";
+import { Box, Tabs, Tab } from "@mui/material";
+
+const TabbedContainer = ({ tabIndex, handleTabChange, labels }) => {
+  return (
+    <Box
+      sx={{
+        backgroundColor: '#fff',
+        py: 1,
+        px: 5,
+        boxShadow: 1,
+      }}
+    >
+      <Tabs
+        value={tabIndex}
+        onChange={handleTabChange}
+        textColor="primary"
+        indicatorColor="primary"
+        variant="standard"
+        centered
+        sx={{ minWidth: 'fit-content' }}
+      >
+        {labels.map((label, index) => (
+          <Tab key={index} label={label} />
+        ))}
+      </Tabs>
+    </Box>
+  );
+};
+
+export default TabbedContainer;

--- a/refacbus_admin/src/components/common/index.js
+++ b/refacbus_admin/src/components/common/index.js
@@ -1,0 +1,2 @@
+export { default as TabbedContainer } from './TabbedContainer';
+export { default as TabPanel } from './TabPanel';

--- a/refacbus_admin/src/context/AdminContext.jsx
+++ b/refacbus_admin/src/context/AdminContext.jsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { auth, realtimeDb } from "../firebase";
+import { onAuthStateChanged } from "firebase/auth";
+import { ref, get } from "firebase/database";
+
+const AdminContext = createContext(null);
+
+export const AdminProvider = ({ children }) => {
+  const [admin, setAdmin] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        console.log("✅ 로그인된 유저 UID:", user.uid);
+        const snapshot = await get(ref(realtimeDb, `admin/${user.uid}`));
+        const adminData = snapshot.val();
+        if (adminData) {
+          setAdmin({ uid: user.uid, ...adminData });
+        } else {
+          setAdmin(null); // 데이터는 없지만 로그인은 되어 있는 경우
+        }
+      } else {
+        setAdmin(null);
+      }
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  return (
+    <AdminContext.Provider value={admin}>
+      {children}
+    </AdminContext.Provider>
+  );
+};
+
+export const useAdmin = () => useContext(AdminContext);

--- a/refacbus_admin/src/main.jsx
+++ b/refacbus_admin/src/main.jsx
@@ -1,12 +1,16 @@
-import { StrictMode } from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom/client';
 import './index.css'
 import App from './App'
 import './index.css';
 import './App.jsx'
+import { AdminProvider } from './context/AdminContext';
+
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+  <React.StrictMode>
+    <AdminProvider>
+      <App />
+    </AdminProvider>
+  </React.StrictMode>
+);

--- a/refacbus_admin/src/pages/DashBoard.jsx
+++ b/refacbus_admin/src/pages/DashBoard.jsx
@@ -6,7 +6,7 @@ import { Typography, List, ListItemButton, ListItemText, Paper } from '@mui/mate
 import { getDatabase, ref, onValue, get } from 'firebase/database';
 import SharedCalendar from "../components/calendar/SharedCalendar";
 import ScheduleCardBox from "../components/DashBoardSchedule/ScheduleCardBox"; 
-
+import NoticeList from '../components/Notice/NoticeList';
 
 const Dashboard = () => {
   const [value, setValue] = useState(new Date());
@@ -68,25 +68,7 @@ const Dashboard = () => {
         />
 
         {/* 공지사항 */}
-        <Box sx={{backgroundColor: '#fff', p: 2, borderRadius: 2,  boxShadow: 3 }}>
-          <Typography variant="h6" gutterBottom>
-            공지사항
-          </Typography>
-          <List>
-            {notices.map((notice, index) => (
-              <ListItemButton
-                key={index}
-                component="a"
-                href={notice.url}
-                target="_blank"
-              >
-                <ListItemText
-                  primary={`${notice.title} (${new Date(notice.date).toLocaleDateString('ko-KR')})`}
-                />
-              </ListItemButton>
-            ))}
-          </List>
-        </Box>
+        <NoticeList notices={notices} />
       </Box>
       <ScheduleCardBox />
     </Box>

--- a/refacbus_admin/src/pages/DashBoard.jsx
+++ b/refacbus_admin/src/pages/DashBoard.jsx
@@ -3,11 +3,16 @@ import Box from '@mui/material/Box';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import { Typography, List, ListItemButton, ListItemText, Paper } from '@mui/material';
-import { getDatabase, ref, onValue } from 'firebase/database';
+import { getDatabase, ref, onValue, get } from 'firebase/database';
+import SharedCalendar from "../components/calendar/SharedCalendar";
+import ScheduleCardBox from "../components/DashBoardSchedule/ScheduleCardBox"; 
+
 
 const Dashboard = () => {
   const [value, setValue] = useState(new Date());
   const [notices, setNotices] = useState([]);
+  const [markedDates, setMarkedDates] = useState([]);
+
 
   useEffect(() => {
     const db = getDatabase();
@@ -22,6 +27,32 @@ const Dashboard = () => {
     });
   }, []);
 
+  useEffect(() => {
+    const fetchMarkedDates = async () => {
+          const db = getDatabase();
+          const scheduleRef = ref(db, "managerSchedules");
+          const snapshot = await get(scheduleRef);
+    
+          if (snapshot.exists()) {
+            const data = snapshot.val();
+    
+            const uniqueDates = new Set();
+            for (const date of Object.keys(data)) {
+              const entries = Object.values(data[date]);
+              if (entries.length > 0) {
+                uniqueDates.add(date);
+              }
+            }
+    
+            setMarkedDates(Array.from(uniqueDates));
+          }
+        };
+    
+        fetchMarkedDates();
+      
+  }, []);
+    
+
   return (
     <Box sx={{ p: 3 }}>
       <Typography variant="h5" gutterBottom>
@@ -30,14 +61,11 @@ const Dashboard = () => {
 
       <Box sx={{ display: 'flex', gap: 2}}>
         {/* 캘린더 */}
-        <Paper elevation={3}
-        sx={{ width: 500, height:400, p: 2,borderRadius: 2, '& .react-calendar': {width: '100%', height:'100%', fontSize: '1.2rem', },}}>
-          <Calendar 
-            onChange={setValue}
-            value={value}
-            className="custom-calendar"
-          />
-        </Paper>
+        <SharedCalendar
+          value={value}
+          onChange={setValue}
+          markedDates={markedDates}
+        />
 
         {/* 공지사항 */}
         <Box sx={{backgroundColor: '#fff', p: 2, borderRadius: 2,  boxShadow: 3 }}>
@@ -60,6 +88,7 @@ const Dashboard = () => {
           </List>
         </Box>
       </Box>
+      <ScheduleCardBox />
     </Box>
   );
 };

--- a/refacbus_admin/src/pages/DriverManagement.jsx
+++ b/refacbus_admin/src/pages/DriverManagement.jsx
@@ -1,557 +1,476 @@
-
 import React, { useState, useEffect } from 'react';
-import {
-  TextField, Box, Table, TableHead, TableCell, TableRow, TableBody,
-  Menu, MenuItem, Dialog, DialogTitle, DialogContent, DialogActions, ListItemText,
-  Checkbox, FormControlLabel, Button, Typography, Paper, Tab, Tabs, FormControl, InputLabel, Select
-} from '@mui/material';
+import { Box,} from '@mui/material';
 import { ref, get, update, push, set } from "firebase/database";
 import { realtimeDb, auth } from "../firebase";
 import { sendPasswordResetEmail } from "firebase/auth";
-import IconButton from "@mui/material/IconButton";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import EditNoteIcon from '@mui/icons-material/EditNote';
-import AccessTimeIcon from "@mui/icons-material/AccessTime";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import AddIcon from "@mui/icons-material/Add";
 import dayjs from "dayjs"; 
-import { getColorByRoute } from "../utils/colorUnits"; 
-
-const TabPanel = ({ children, value, index }) => {
-  return (
-    <div hidden={value !== index}>
-      {value === index && (
-        <Box sx={{ p: 3 }}>
-          {children}
-        </Box>
-      )}
-    </div>
-  );
-};
+import { UserTable, MemoDialog, MemoHistoryDialog } from '../components/User';
+import { TabbedContainer, TabPanel } from '../components/common';
+import { DriverListTable, DriverScheduleDialog, DrivingHistoryDialog, ResetPasswordDialog } from '../components/Driver';
+import { timeSlots, days, getDayIndex } from '../components/Driver/constants';
+import SearchBar from '../components/common/SearchBar';
 
 const DriverManagement = () => {
-  const [tabIndex, setTabIndex] = useState(0);
 
+  // 기본 UI 상태 및 탭 변환
+  const [tabIndex, setTabIndex] = useState(0);
   const handleTabChange = (event, newValue) => {
     setTabIndex(newValue);
   };
 
+  //사용자 목록 상태 및 검색
   const [searchKeyword, setSearchKeyword] = useState('');
-    const [filteredUsers, setFilteredUsers] = useState([]);
-    const [allUsers, setAllUsers] = useState([]);
+  const [filteredUsers, setFilteredUsers] = useState([]);
+  const [allUsers, setAllUsers] = useState([]);
   
-    const [anchorEl, setAnchorEl] = useState(null);
-    const [anchorUserId, setAnchorUserId] = useState(null);
-  
-    const [isMemoOpen, setIsMemoOpen] = useState(false);
-    const [selectedUserForMemo, setSelectedUserForMemo] = useState(null);
-    const [memoText, setMemoText] = useState("");
-    const [isWarning, setIsWarning] = useState(false);
-    const [isBan, setIsBan] = useState(false);
-    const [isMemoHistoryOpen, setIsMemoHistoryOpen] = useState(false);
-    const [selectedMemoList, setSelectedMemoList] = useState([]);
-    const [memoFilter, setMemoFilter] = useState("all");
-    const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-    const [editingUser, setEditingUser] = useState(null);
-    const [editedEmail, setEditedEmail] = useState("");
-    const [editedName, setEditedName] = useState("");
-    const [resetEmail, setResetEmail] = useState('');
-    const [isResetOpen, setIsResetOpen] = useState(false);
-    const [targetUser, setTargetUser] = useState(null);
-    const [selectedRouteDetails, setSelectedRouteDetails] = useState(null);
-    const [selectedDriver, setSelectedDriver] = useState(null);
-    const [drivingHistory, setDrivingHistory] = useState([]);
-    const [isHistoryOpen, setIsHistoryOpen] = useState(false);
-    const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
-    const [currentTargetUser, setCurrentTargetUser] = useState(null);
-    const [pinnedRoutes, setPinnedRoutes] = useState([]);
-    const [selectedRoute, setSelectedRoute] = useState('');
-    const [selectedRouteId, setSelectedRouteId] = useState('');
-    const [availableTimes, setAvailableTimes] = useState([]);
-    const [selectedTime, setSelectedTime] = useState('');
-    const [expandedDriverUid, setExpandedDriverUid] = useState(null);
-    const [selectedCellTime, setSelectedCellTime] = useState('');
-    const [driverSchedule, setDriverSchedule] = useState({});
-    const [selectedDays, setSelectedDays] = useState([]);
-    const [duration, setDuration] = useState('');
-    const [highlightedCells, setHighlightedCells] = useState(new Set());
-    const [coloredCells, setColoredCells] = useState([]); 
-    const [driverSchedules, setDriverSchedules] = useState({});
-    const [driverList, setDriverList] = useState([]);
-    const [coloredSchedule, setColoredSchedule] = useState({});
-    const [isEditing, setIsEditing] = useState(false);
-    const [editingScheduleKey, setEditingScheduleKey] = useState(null);
-
-
-
-    useEffect(() => {
-      const fetchUsers = async () => {
-        const snapshot = await get(ref(realtimeDb, "drivers"));
-        const usersData = snapshot.val();
-        const usersArray = Object.entries(usersData).map(([uid, value]) => ({
-          uid,
-          ...value,
-        }));
-        setAllUsers(usersArray);
-        setFilteredUsers(usersArray);
-      };
-      fetchUsers();
-    }, []);
-  
-    useEffect(() => {
-      const filtered = allUsers.filter((user) =>
-        (user.name ?? '').toLowerCase().includes(searchKeyword.toLowerCase())
-      );
-      setFilteredUsers(filtered);
-    }, [searchKeyword, allUsers]);
-  
-    useEffect(() => {
-      const highlightSet = new Set();
-
-      Object.values(driverSchedule).forEach((entry) => {
-        const { days, time, duration } = entry;
-        if (!days || !time || !duration) return;
-
-        days.forEach((day) => {
-          const baseHour = parseInt(time.split(":")[0], 10);
-          for (let i = 0; i < duration; i++) {
-            const hour = baseHour + i;
-            highlightSet.add(`${day}_${hour}`);
-          }
-        });
-      });
-
-      setHighlightedCells(highlightSet);
-    }, [driverSchedule]);
-
-    useEffect(() => {
-      
-      if (currentTargetUser?.uid) {
-        fetchDriverSchedule(currentTargetUser.uid);
-      }
-    }, [currentTargetUser]);
-
-    useEffect(() => {
-      const fetchDriverList = async () => {
-        const snapshot = await get(ref(realtimeDb, "drivers"));
-        if (snapshot.exists()) {
-          const driversData = snapshot.val();
-          const driversArray = Object.entries(driversData).map(([uid, info]) => ({
-            uid,
-            ...info,
-          }));
-          setDriverList(driversArray);
-        }
-      };
-
-      fetchDriverList();
-    }, []);
-
-
-    useEffect(() => {
-      if (driverList.length > 0 && !currentTargetUser) {
-        setCurrentTargetUser(driverList[0]);
-      }
-    }, [driverList, currentTargetUser]);
-
-      useEffect(() => {
-      if (driverList.length > 0) {
-        driverList.forEach((driver) => {
-          fetchDriverSchedule(driver.uid);
-        });
-      }
-    }, [driverList]);
-
-
-    
-    const handleMenuOpen = (event, user) => {
-      setAnchorEl(event.currentTarget);
-      setAnchorUserId(user.uid);
+  //MoreVertIcon 메뉴 클릭 시
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [anchorUserId, setAnchorUserId] = useState(null);
+  useEffect(() => {
+    const fetchUsers = async () => {
+      const snapshot = await get(ref(realtimeDb, "drivers"));
+      const usersData = snapshot.val();
+      const usersArray = Object.entries(usersData).map(([uid, value]) => ({
+        uid,
+        ...value,
+      }));
+      setAllUsers(usersArray);
+      setFilteredUsers(usersArray);
     };
+    fetchUsers();
+  }, []);
   
-    const handleMenuClose = () => {
-      setAnchorEl(null);
-      setAnchorUserId(null);
-    };
-  
-    const handleOpenMemo = (user) => {
-      setSelectedUserForMemo(user);
-      setIsMemoOpen(true);
-    };
-  
-    const handleCloseMemo = () => {
-      setSelectedUserForMemo(null);
-      setIsMemoOpen(false);
-      setMemoText("");
-      setIsWarning(false);
-      setIsBan(false);
-    };
-  
-  
-    
-    const handleSubmitMemo = async () => {
-      if (!selectedUserForMemo) return;
-  
-      const userRef = ref(realtimeDb, `drivers/${selectedUserForMemo.uid}`);
-      const memoRef = ref(realtimeDb, `drivers/${selectedUserForMemo.uid}/memo`);
-  
-      const newMemo = {
-        text: memoText.trim(),
-        timestamp: dayjs().format('YYYY-MM-DD'),
-        writer: '관리자A',
-        type: isBan ? 'ban' : isWarning ? 'warning' : 'note'
-      };
-  
-      await push(memoRef, newMemo);
-  
-      const snapshot = await get(userRef);
-      const existingData = snapshot.val();
-  
-      const updates = {};
-  
-      if (isWarning) {
-        updates.warningCount = (existingData?.warningCount ?? 0) + 1;
-      }
-      if (isBan) {
-        updates.isBanned = true;
-      }
-  
-      if (Object.keys(updates).length > 0) {
-        await update(userRef, updates);
-      }
-  
-      setAllUsers((prev) =>
-        prev.map((u) =>
-          u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
-        )
-      );
-
-      setFilteredUsers((prev) =>
-        prev.map((u) =>
-          u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
-        )
-      );
-  
-      handleCloseMemo();
-    };
-  
-  
-      const handleUnban = async (uid) => {
-      await update(ref(realtimeDb, `drivers/${uid}`), { isBanned: false });
-  
-      setAllUsers((prev) =>
-        prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
-      );
-      setFilteredUsers((prev) =>
-        prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
-      );
-  
-      handleMenuClose();
-    };
-  
-    const handleOpenMemoHistory = async (user) => {
-      const memoRef = ref(realtimeDb, `drivers/${user.uid}/memo`);
-      const snapshot = await get(memoRef);
-  
-      if (snapshot.exists()) {
-        const memoObject = snapshot.val();
-        const memoArray = Object.values(memoObject);
-  
-        const sorted = memoArray.sort(
-          (a, b) => dayjs(b.timestamp).valueOf() - dayjs(a.timestamp).valueOf()
-        );
-        setSelectedMemoList(sorted);
-      } else {
-        setSelectedMemoList([]);
-      }
-  
-      setIsMemoHistoryOpen(true);
-    };
-  
-  
-    const filteredMemoList = selectedMemoList.filter(memo => 
-    memoFilter === "all" ? true : memo.type === memoFilter
+  useEffect(() => {
+    const filtered = allUsers.filter((user) =>
+      (user.name ?? '').toLowerCase().includes(searchKeyword.toLowerCase())
     );
-  
-    const handleOpenEditDialog = (user) => {
-      setEditingUser(user);
-      setEditedEmail(user.email ?? "");
-      setEditedName(user.name ?? "");
-      setIsEditDialogOpen(true);
-    };
-  
-    const handleOpenReset = (user) => {
-      setTargetUser(user);
-      setResetEmail(user.email); 
-      setIsResetOpen(true);
-    };
-  
-    const handleSendResetEmail = async () => {
-      try {
-        await sendPasswordResetEmail(auth, resetEmail.trim());
-        alert("비밀번호 초기화 메일이 전송되었습니다.");
-        setIsResetOpen(false);
-      } catch (error) {
-        alert("이메일 전송 실패: " + error.message);
-      }
-    };
+    setFilteredUsers(filtered);
+  }, [searchKeyword, allUsers]);
 
-    
+  //운행 이력 관련
+  const [selectedDriver, setSelectedDriver] = useState(null);
+  const [drivingHistory, setDrivingHistory] = useState([]);
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
-    const handleTimeOpen = async (e, user) => {
-      setSelectedDriver(user);
-      setIsHistoryOpen(true);
+  //스케줄 등록 관련
+  const [currentTargetUser, setCurrentTargetUser] = useState(null);
+  const [pinnedRoutes, setPinnedRoutes] = useState([]);
+  const [selectedRoute, setSelectedRoute] = useState('');
+  const [selectedRouteId, setSelectedRouteId] = useState('');
+  const [availableTimes, setAvailableTimes] = useState([]);
+  const [selectedTime, setSelectedTime] = useState('');
+  const [selectedDays, setSelectedDays] = useState([]);
+  const [duration, setDuration] = useState('');
+  const [selectedCellTime, setSelectedCellTime] = useState('');
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingScheduleKey, setEditingScheduleKey] = useState(null);
 
-      try {
-        const snapshot = await get(ref(realtimeDb, `drivers/${user.uid}/drived`));
-        if (snapshot.exists()) {
-          const data = snapshot.val();
-          const records = Object.values(data)
-            .map((item) => ({
-              route: item.route,
-              date: item.date,
-              time: item.time,
-              endTime: item.endTime,
-            }))
-            .sort((a, b) => {
-              const aDate = new Date(`${a.date}T${a.time}`);
-              const bDate = new Date(`${b.date}T${b.time}`);
-              return bDate - aDate;
-            });
-          setDrivingHistory(records);
-        } else {
-          setDrivingHistory([]);
+  //스케줄 시각화 관련
+  const [expandedDriverUid, setExpandedDriverUid] = useState(null);
+  const [driverSchedule, setDriverSchedule] = useState({});
+  const [coloredSchedule, setColoredSchedule] = useState({});
+  const [highlightedCells, setHighlightedCells] = useState(new Set()); 
+  const [driverSchedules, setDriverSchedules] = useState({});
+  const [driverList, setDriverList] = useState([]);
+
+  //메모 관련 및 다이얼로그
+  const [isMemoOpen, setIsMemoOpen] = useState(false);
+  const [selectedUserForMemo, setSelectedUserForMemo] = useState(null);
+  const [memoText, setMemoText] = useState("");
+  const [isWarning, setIsWarning] = useState(false);
+  const [isBan, setIsBan] = useState(false);
+  const [isMemoHistoryOpen, setIsMemoHistoryOpen] = useState(false);
+  const [selectedMemoList, setSelectedMemoList] = useState([]);
+  const [memoFilter, setMemoFilter] = useState("all");
+
+  //사용자 정보 수정/초기화 다이얼로그
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [editingUser, setEditingUser] = useState(null);
+  const [editedEmail, setEditedEmail] = useState("");
+  const [editedName, setEditedName] = useState("");
+  const [resetEmail, setResetEmail] = useState('');
+  const [isResetOpen, setIsResetOpen] = useState(false);
+  const [targetUser, setTargetUser] = useState(null);
+
+  useEffect(() => {
+    const highlightSet = new Set();
+
+    Object.values(driverSchedule).forEach((entry) => {
+      const { days, time, duration } = entry;
+      if (!days || !time || !duration) return;
+
+      days.forEach((day) => {
+        const baseHour = parseInt(time.split(":")[0], 10);
+        for (let i = 0; i < duration; i++) {
+          const hour = baseHour + i;
+          highlightSet.add(`${day}_${hour}`);
         }
-      } catch (error) {
-        console.error("운행 이력 불러오기 실패:", error);
-      }
-    };
-
-    const handleOpenSchedule = (user) => {
-      setExpandedDriverUid((prevUid) => (prevUid === user.uid ? null : user.uid));
-    };
-
-    const days = ["월", "화", "수", "목", "금"];
-    const timeSlots = [
-      "08:00", "09:00", "10:00", "11:00", "12:00",
-      "16:00", "17:00", "18:00", "19:00",
-    ];
-
-    
-    const handleOpenAddDialog = (user) => {
-      setCurrentTargetUser(user);
-      setIsAddDialogOpen(true);
-      fetchPinnedRoutes(user.uid);
-    };
-
-    const handleCloseAddDialog = () => {
-      setIsAddDialogOpen(false);
-      setCurrentTargetUser(null);
-      setIsEditing(false);
-      setEditingScheduleKey(null);
-    };
-
-    
-    const fetchPinnedRoutes = async (uid) => {
-      try {
-        const snapshot = await get(ref(realtimeDb, `routes`));
-        if (snapshot.exists()) {
-          const data = snapshot.val();
-          const pinned = Object.entries(data)
-            .filter(([_, route]) => route.isPinned)
-            .map(([key, route]) => ({
-              id: key,
-              name: route.name,
-            }));
-          setPinnedRoutes(pinned);
-        } else {
-          setPinnedRoutes([]);
-        }
-      } catch (err) {
-        console.error("노선 목록 가져오기 실패:", err);
-      }
-    };
-
-
-      const handleRouteSelect = async (e) => {
-          const routeName = e.target.value;
-          setSelectedRoute(routeName);
-
-          const selected = pinnedRoutes.find((route) => route.name === routeName);
-          if (!selected) return;
-
-          setSelectedRouteId(selected.id);
-          setSelectedRouteDetails(selected); 
-          try {
-            const snapshot = await get(ref(realtimeDb, `routes/${selected.id}/times`));
-            if (snapshot.exists()) {
-              const timeList = Object.values(snapshot.val());
-              setAvailableTimes(timeList);
-            } else {
-              setAvailableTimes([]);
-            }
-          } catch (err) {
-            console.error("시간 목록 불러오기 실패:", err);
-          }
-        };
-
-
-    
-    const handleSaveSchedule = async () => {
-
-      if (!currentTargetUser || !selectedDays || !selectedTime || !selectedRoute) {
-        console.log("조건 안 맞아서 return 됨!");
-        return;
-      }
-
-      const newSchedule = {
-        route: selectedRoute,
-        time: selectedTime,
-        duration: duration, 
-        days: selectedDays,
-        createdAt: new Date().toISOString()
-      };
-
-
-      try {
-        const scheduleRef = ref(
-          realtimeDb,
-          `drivers/${currentTargetUser.uid}/schedule`
-        );
-
-
-        if (isEditing && editingScheduleKey) {
-          const targetRef = ref(
-            realtimeDb,
-            `drivers/${currentTargetUser.uid}/schedule/${editingScheduleKey}`
-          );
-          await set(targetRef, newSchedule);
-        } else {
-          const newRef = push(scheduleRef);
-          await set(newRef, newSchedule);
-        }
-
-        setIsAddDialogOpen(false);
-        setSelectedRoute('');
-        setSelectedTime('');
-        setSelectedDays([]);
-        setSelectedCellTime('');
-        setDuration('');
-        setIsEditing(false); 
-        setEditingScheduleKey(null);
-
-        fetchDriverSchedule(currentTargetUser.uid);
-        setExpandedDriverUid(currentTargetUser.uid);
-
-      } catch (err) {
-        console.error("스케줄 저장 실패:", err);
-      }
-    };
-
-    
-    const fetchDriverSchedule = async (uid) => {
-  const scheduleRef = ref(realtimeDb, `drivers/${uid}/schedule`);
-  const snapshot = await get(scheduleRef);
-
-  if (snapshot.exists()) {
-    const data = snapshot.val();
-    console.log("🔥 가져온 스케줄", data);
-
-    setDriverSchedules((prev) => ({ ...prev, [uid]: data }));
-
-    const newColored = analyzeSchedule(data);
-    console.log("🎨 색칠할 셀", newColored);
-    setColoredSchedule((prev) => ({
-       ...prev, [uid]: newColored })); 
-  } else {
-    console.log("❌ 해당 유저 스케줄 없음:", uid);
-  }
-};
-
-
-
-   
-    
-   const analyzeSchedule = (scheduleObj) => {
-      const newColoredCells = [];
-
-      Object.values(scheduleObj).forEach((item) => {
-        const { days, time, duration } = item;
-        if (!days || !time || !duration) return;
-
-        const [hourStr, minuteStr] = time.split(":");
-        const hour = parseInt(hourStr, 10);
-        const minute = parseInt(minuteStr, 10);
-
-        let startIndex = -1;
-
-        for (let i = 0; i < timeSlots.length; i++) {
-          const slotHour = parseInt(timeSlots[i].split(":")[0], 10);
-          const nextSlotHour =
-            i < timeSlots.length - 1
-              ? parseInt(timeSlots[i + 1].split(":")[0], 10)
-              : 24;
-
-          if (hour >= slotHour && hour < nextSlotHour) {
-            startIndex = i;
-            break;
-          }
-        }
-
-        if (startIndex === -1) return; 
-        days.forEach((day) => {
-          const col = getDayIndex(day);
-          for (let i = 0; i < duration; i++) {
-            const row = startIndex + i;
-            const cellKey = `${col}-${row}`;
-            newColoredCells.push(cellKey);
-          }
-        });
       });
+    });
 
-      return newColoredCells;
+    setHighlightedCells(highlightSet);
+  }, [driverSchedule]);
+
+  useEffect(() => {
+      
+    if (currentTargetUser?.uid) {
+      fetchDriverSchedule(currentTargetUser.uid);
+    }
+  }, [currentTargetUser]);
+
+  useEffect(() => {
+    const fetchDriverList = async () => {
+      const snapshot = await get(ref(realtimeDb, "drivers"));
+      if (snapshot.exists()) {
+        const driversData = snapshot.val();
+        const driversArray = Object.entries(driversData).map(([uid, info]) => ({
+          uid,
+          ...info,
+        }));
+        setDriverList(driversArray);
+      }
     };
 
+    fetchDriverList();
+  }, []);
 
 
+  useEffect(() => {
+    if (driverList.length > 0 && !currentTargetUser) {
+      setCurrentTargetUser(driverList[0]);
+    }
+  }, [driverList, currentTargetUser]);
 
+  useEffect(() => {
+    if (driverList.length > 0) {
+      driverList.forEach((driver) => {
+        fetchDriverSchedule(driver.uid);
+      });
+    }
+  }, [driverList]);
 
-    const getDayIndex = (day) => {
-      const daysKor = ['월', '화', '수', '목', '금'];
-      return daysKor.indexOf(day);
+  const handleMenuOpen = (event, user) => {
+    setAnchorEl(event.currentTarget);
+    setAnchorUserId(user.uid);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setAnchorUserId(null);
+  };  
+  
+  const handleOpenMemo = (user) => {
+    setSelectedUserForMemo(user);
+    setIsMemoOpen(true);
+  };  
+
+  const handleCloseMemo = () => {
+    setSelectedUserForMemo(null);
+    setIsMemoOpen(false);
+    setMemoText("");
+    setIsWarning(false);
+    setIsBan(false);
+  };  
+    
+  const handleSubmitMemo = async () => {
+    if (!selectedUserForMemo) return;
+  
+    const userRef = ref(realtimeDb, `drivers/${selectedUserForMemo.uid}`);
+    const memoRef = ref(realtimeDb, `drivers/${selectedUserForMemo.uid}/memo`);
+  
+    const newMemo = {
+      text: memoText.trim(),
+      timestamp: dayjs().format('YYYY-MM-DD'),
+      writer: '관리자A',
+      type: isBan ? 'ban' : isWarning ? 'warning' : 'note'
+    };
+  
+    await push(memoRef, newMemo);
+  
+    const snapshot = await get(userRef);
+    const existingData = snapshot.val();
+  
+    const updates = {};
+  
+    if (isWarning) {
+      updates.warningCount = (existingData?.warningCount ?? 0) + 1;
+    }
+    if (isBan) {
+      updates.isBanned = true;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await update(userRef, updates);
+    }
+
+    setAllUsers((prev) =>
+      prev.map((u) =>
+        u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
+      )
+    );
+    setFilteredUsers((prev) =>
+      prev.map((u) =>
+        u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
+      )
+    );
+
+    handleCloseMemo();
+  };
+    
+  const handleOpenMemoHistory = async (user) => {
+    const memoRef = ref(realtimeDb, `drivers/${user.uid}/memo`);
+    const snapshot = await get(memoRef);
+
+    if (snapshot.exists()) {
+      const memoObject = snapshot.val();
+      const memoArray = Object.values(memoObject);
+
+      const sorted = memoArray.sort(
+        (a, b) => dayjs(b.timestamp).valueOf() - dayjs(a.timestamp).valueOf()
+      );
+      setSelectedMemoList(sorted);
+    } else {
+      setSelectedMemoList([]);
+    }
+
+    setIsMemoHistoryOpen(true);
+  };
+    
+  const handleOpenEditDialog = (user) => {
+    setEditingUser(user);
+    setEditedEmail(user.email ?? "");
+    setEditedName(user.name ?? "");
+    setIsEditDialogOpen(true);
+  };
+    
+  const handleOpenReset = (user) => {
+    setTargetUser(user);
+    setResetEmail(user.email); 
+    setIsResetOpen(true);
+  };
+  
+  const handleSendResetEmail = async () => {
+    try {
+      await sendPasswordResetEmail(auth, resetEmail.trim());
+      alert("비밀번호 초기화 메일이 전송되었습니다.");
+      setIsResetOpen(false);
+    } catch (error) {
+      alert("이메일 전송 실패: " + error.message);
+    }
+  };  
+    
+  const handleUnban = async (uid) => {
+    await update(ref(realtimeDb, `drivers/${uid}`), { isBanned: false });
+  
+    setAllUsers((prev) =>
+      prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
+    );
+    setFilteredUsers((prev) =>
+      prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
+    );
+
+    handleMenuClose();
+  };
+  
+      
+  const handleTimeOpen = async (e, user) => {
+    setSelectedDriver(user);
+    setIsHistoryOpen(true);
+
+    try {
+      const snapshot = await get(ref(realtimeDb, `drivers/${user.uid}/drived`));
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+        const records = Object.values(data)
+          .map((item) => ({
+            route: item.route,
+            date: item.date,
+            time: item.time,
+            endTime: item.endTime,
+          }))
+          .sort((a, b) => {
+            const aDate = new Date(`${a.date}T${a.time}`);
+            const bDate = new Date(`${b.date}T${b.time}`);
+            return bDate - aDate;
+          });
+        setDrivingHistory(records);
+      } else {
+        setDrivingHistory([]);
+      }
+    } catch (error) {
+      console.error("운행 이력 불러오기 실패:", error);
+    }
+  };
+    
+  const handleOpenSchedule = (user) => {
+    setExpandedDriverUid((prevUid) => (prevUid === user.uid ? null : user.uid));
+  };
+
+    
+  const handleOpenAddDialog = (user) => {
+    setCurrentTargetUser(user);
+    setIsAddDialogOpen(true);
+    fetchPinnedRoutes(user.uid);
+  };
+
+  const handleCloseAddDialog = () => {
+    setIsAddDialogOpen(false);
+    setCurrentTargetUser(null);
+    setIsEditing(false);
+    setEditingScheduleKey(null);
+  };
+  
+
+  const [selectedRouteDetails, setSelectedRouteDetails] = useState(null);
+  const handleRouteSelect = async (e) => {
+    const routeName = e.target.value;
+    setSelectedRoute(routeName);
+
+    const selected = pinnedRoutes.find((route) => route.name === routeName);
+    if (!selected) return;
+
+    setSelectedRouteId(selected.id);
+    setSelectedRouteDetails(selected); 
+    try {
+      const snapshot = await get(ref(realtimeDb, `routes/${selected.id}/times`));
+      if (snapshot.exists()) {
+        const timeList = Object.values(snapshot.val());
+        setAvailableTimes(timeList);
+      } else {
+        setAvailableTimes([]);
+      }
+    } catch (err) {
+      console.error("시간 목록 불러오기 실패:", err);
+    }
+  };
+
+  const handleSaveSchedule = async () => {
+    if (!currentTargetUser || !selectedDays || !selectedTime || !selectedRoute) {
+      console.log("조건 안 맞아서 return 됨!");
+      return;
+    }
+    const newSchedule = {
+      route: selectedRoute,
+      time: selectedTime,
+      duration: duration, 
+      days: selectedDays,
+      createdAt: new Date().toISOString()
     };
 
+    try {
+      const scheduleRef = ref(
+        realtimeDb,
+        `drivers/${currentTargetUser.uid}/schedule`
+      );
 
+    if (isEditing && editingScheduleKey) {
+      const targetRef = ref(
+        realtimeDb,
+       `drivers/${currentTargetUser.uid}/schedule/${editingScheduleKey}`
+      );
+      await set(targetRef, newSchedule);
+    } else {
+      const newRef = push(scheduleRef);
+      await set(newRef, newSchedule);
+    }
+
+    setIsAddDialogOpen(false);
+    setSelectedRoute('');
+    setSelectedTime('');
+    setSelectedDays([]);
+    setSelectedCellTime('');
+    setDuration('');
+    setIsEditing(false); 
+    setEditingScheduleKey(null);
+    fetchDriverSchedule(currentTargetUser.uid);
+    setExpandedDriverUid(currentTargetUser.uid);
+
+    } catch (err) {
+     console.error("스케줄 저장 실패:", err);
+    }
+  };
+
+  const fetchPinnedRoutes = async (uid) => {
+    try {
+      const snapshot = await get(ref(realtimeDb, `routes`));
+      if (snapshot.exists()) {
+        const data = snapshot.val();
+        const pinned = Object.entries(data)
+          .filter(([_, route]) => route.isPinned)
+          .map(([key, route]) => ({
+            id: key,
+            name: route.name,
+          }));
+        setPinnedRoutes(pinned);
+      } else {
+        setPinnedRoutes([]);
+      }
+    } catch (err) {
+      console.error("노선 목록 가져오기 실패:", err);
+    }
+  };
+
+  const fetchDriverSchedule = async (uid) => {
+    const scheduleRef = ref(realtimeDb, `drivers/${uid}/schedule`);
+    const snapshot = await get(scheduleRef);
+    if (snapshot.exists()) {
+      const data = snapshot.val();
+
+      setDriverSchedules((prev) => ({ ...prev, [uid]: data }));
+
+      const newColored = analyzeSchedule(data);
+      setColoredSchedule((prev) => ({
+        ...prev, [uid]: newColored })); 
+    } 
+  };
+
+  const analyzeSchedule = (scheduleObj) => {
+    const newColoredCells = [];
+
+    Object.values(scheduleObj).forEach((item) => {
+      const { days, time, duration } = item;
+      if (!days || !time || !duration) return;
+
+      const [hourStr, minuteStr] = time.split(":");
+      const hour = parseInt(hourStr, 10);
+      const minute = parseInt(minuteStr, 10);
+      let startIndex = -1;
+
+      for (let i = 0; i < timeSlots.length; i++) {
+        const slotHour = parseInt(timeSlots[i].split(":")[0], 10);
+        const nextSlotHour =
+          i < timeSlots.length - 1
+            ? parseInt(timeSlots[i + 1].split(":")[0], 10)
+            : 24;
+
+        if (hour >= slotHour && hour < nextSlotHour) {
+          startIndex = i;
+          break;
+        }
+      }
+
+      if (startIndex === -1) return; 
+      days.forEach((day) => {
+        const col = getDayIndex(day);
+        for (let i = 0; i < duration; i++) {
+          const row = startIndex + i;
+          const cellKey = `${col}-${row}`;
+          newColoredCells.push(cellKey);
+        }
+      });
+    });
+    return newColoredCells;
+  };
 
   return (
     <Box sx={{ width: '100%' }}>
-      
-      <Box
-        sx={{
-          backgroundColor: '#fff',
-          py: 1,
-          px: 5,
-          boxShadow: 1,
-        }}
-      >
-        <Tabs
-          sx={{
-            minWidth: 'fit-content',  }}
-          value={tabIndex}
-          onChange={handleTabChange}
-          textColor="primary"
-          indicatorColor="primary"
-          variant="standard" 
-          centered       
-          
-        >
-          <Tab label="기사별 운행 이력" />
-          <Tab label="기사 계정 관리" />
-        </Tabs>
-      </Box>
+      <TabbedContainer
+        tabIndex={tabIndex}
+        handleTabChange={handleTabChange}
+        labels={["기사별 운행 이력", "기사 계정 관리"]}
+      />
 
-      {/* 회색 박스 본문 */}
       <Box
         sx={{
           backgroundColor: '#f5f5f5',
@@ -561,511 +480,102 @@ const DriverManagement = () => {
       >
         <TabPanel value={tabIndex} index={0}>
           <Box sx={{ width: '100%', height: '100%', backgroundColor: '#fff',  }}>
-                <TextField
-                  label="이름으로 검색"
-                  variant="outlined"
-                  size="small"
-                  value={searchKeyword}
-                  onChange={(e) => setSearchKeyword(e.target.value)}
-                  sx={{ width: '500px', mb: 2,  }}
-                />
-          
-                <Table>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>uid</TableCell>
-                      <TableCell>아이디</TableCell>
-                      <TableCell>이름</TableCell>
-                      <TableCell>가입 날짜</TableCell>
-                      <TableCell>운행 시간 관리</TableCell>
-                      <TableCell>운행 일정 관리</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {filteredUsers.map((user) => (
-                      <React.Fragment key={user.uid}>
-                        <TableRow>
-                          <TableCell>{user.uid}</TableCell>
-                          <TableCell>{user.email}</TableCell>
-                          <TableCell>{user.name}</TableCell>
-                          <TableCell>{user.joinDate}</TableCell>
-                          <TableCell>
-                            <IconButton onClick={(e) => handleTimeOpen(e, user)}>
-                              <AccessTimeIcon />
-                            </IconButton>
-                          </TableCell>
-                          <TableCell>
-                            <IconButton onClick={() => handleOpenSchedule(user)}>
-                              {expandedDriverUid === user.uid ? (
-                            <ExpandLessIcon />
-                          ) : (
-                            <ExpandMoreIcon />
-                          )}
-                            </IconButton>
-                          </TableCell>
-                        </TableRow>
-
-                        {/* 아코디언 펼쳐지는 영역 */}
-                        {expandedDriverUid === user.uid && (
-                          <TableRow>
-                            <TableCell colSpan={6}>
-                              <Box sx={{ p: 2, backgroundColor: "#f9f9f9", borderRadius: 2,display: "flex",
-                                    justifyContent: "space-between",
-                                    alignItems: "center",
-                                    width: "100%",
-                                    mb: 2, }}>           
-                                  <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-                                    {user.name}님의 주간 스케줄표
-                                  </Typography>
-                                  <Button
-                                    variant="contained"
-                                    size="small"
-                                    startIcon={<AddIcon />}
-                                    onClick={() => handleOpenAddDialog(user)}
-                                  >
-                                    추가
-                                  </Button>
-                                </Box>
-                                
-
-                                {/* 아래쪽 시간표 테이블은 따로 */}
-                                <Table sx={{
-                                        tableLayout: 'fixed', 
-                                        width: '100%',    
-                                      }}>
-                                  <TableHead>
-                                    <TableRow>
-                                      <TableCell>시간</TableCell>
-                                      {days.map((day) => (
-                                        <TableCell key={day} align="center">
-                                          {day}
-                                        </TableCell>
-                                      ))}
-                                    </TableRow>
-                                  </TableHead>
-                                  <TableBody>
-                                    {timeSlots.map((time, rowIndex) => (
-                                      <TableRow key={time}>
-                                        <TableCell>{time}</TableCell>
-                                          {days.map((day, colIndex) => {
-                                            const cellKey = `${colIndex}-${rowIndex}`;
-                                            const isColored = coloredSchedule[user.uid]?.includes(cellKey);
-                                            let routeText = '';
-                                            let isStartCell = false;
-                                            let bgColor = "inherit"; 
-                                            const scheduleData = driverSchedules[user.uid];
-                                            if (scheduleData) {
-                                              Object.values(scheduleData).forEach(({ days, time, duration, route }) => {
-                                                const startIndex = timeSlots.findIndex((t) => {
-                                                  const [h, m] = time.split(":").map(Number);
-                                                  const [slotH] = t.split(":").map(Number);
-                                                  return h >= slotH && h < slotH + 1;
-                                                });
-
-                                                const col = getDayIndex(day);
-                                                if (startIndex === -1 || !days.includes(day)) return;
-
-                                                const row = rowIndex;
-                                                if (row >= startIndex && row < startIndex + duration) {
-                                                  if (row === startIndex) {
-                                                    routeText = `${route}\n(${time})`;
-                                                    isStartCell = true;
-                                                  }
-                                                  bgColor = getColorByRoute(route);
-                                                }
-                                              });
-                                            }
-
-                                          return (
-                                            <TableCell
-                                              key={day}
-                                              align="center"
-                                              sx={{
-                                                border: "1px solid #ddd",
-                                                minWidth: "120px",
-                                                height: 40,   
-                                                backgroundColor: isColored ? bgColor : "inherit",
-                                                color: isColored ? "#000" : "inherit",
-                                                whiteSpace: "pre-line",
-                                                cursor: isColored ? "pointer" : "default",
-                                                wordBreak: "break-word",
-                                                textAlign: "center",
-                                                lineHeight: 1.2,
-                                                padding: "4px",
-                                                userSelect: "none"
-                                              }}
-                                              onClick={() => {
-                                                if (!isColored) return; 
-
-                                                const matchedSchedule = Object.values(driverSchedules[user.uid]).find(
-                                                  ({ days, time, duration }) => {
-                                                    const startIdx = timeSlots.findIndex((slot) => {
-                                                      const [h, m] = time.split(":").map(Number);
-                                                      const [slotH] = slot.split(":").map(Number);
-                                                      return h >= slotH && h < slotH + 1;
-                                                    });
-
-                                                    return (
-                                                      days.includes(day) &&
-                                                      rowIndex >= startIdx &&
-                                                      rowIndex < startIdx + duration
-                                                    );
-                                                  }
-                                                );
-
-                                                if (matchedSchedule) {
-                                                  const scheduleKey = Object.entries(driverSchedules[user.uid]).find(
-                                                  ([key, value]) =>
-                                                    value.time === matchedSchedule.time &&
-                                                    value.duration === matchedSchedule.duration &&
-                                                    value.route === matchedSchedule.route &&
-                                                    JSON.stringify(value.days) === JSON.stringify(matchedSchedule.days)
-                                                )?.[0]; 
-
-                                                fetchPinnedRoutes(user.uid).then(() => {
-                                                  setSelectedDays(matchedSchedule.days);
-                                                  setSelectedTime(matchedSchedule.time);
-                                                  setDuration(matchedSchedule.duration);
-                                                  setSelectedRoute(matchedSchedule.route);
-                                                  setCurrentTargetUser(user);
-                                                  setIsEditing(true); 
-                                                  setEditingScheduleKey(scheduleKey);
-                                                  handleRouteSelect({
-                                                    target: { value: matchedSchedule.route },
-                                                  });
-                                                  setIsAddDialogOpen(true);
-                                                }); 
-                                              }
-                                              }}
-                                            >
-                                              {isStartCell && (
-                                                <Typography variant="caption" sx={{ fontSize: "0.7rem", fontWeight: 600, cursor: "inherit", }}>
-                                                  {routeText}
-                                                </Typography>
-                                              )}
-                                            </TableCell>
-
-                                          );
-                                        })}
-                                      </TableRow>
-                                    ))}
-                                  </TableBody>
-
-                                </Table>
-                              
-                            </TableCell>
-                          </TableRow>
-
-                        )}
-                      </React.Fragment>
-                    ))}
-                  </TableBody>
-
-                </Table>
-                <Dialog open={isAddDialogOpen} onClose={handleCloseAddDialog} 
-                  PaperProps={{
-                    sx: {
-                      width: "600px", 
-                    },
-                  }}>
-                  <DialogTitle>스케줄 추가</DialogTitle>
-                  <DialogContent>
-                    <Typography>노선 스케줄 등록</Typography>
-                  
-                      <FormControl fullWidth sx={{ mt: 2 }}>
-                        <InputLabel id="route-select-label">노선 선택</InputLabel>
-                        <Select
-                          labelId="route-select-label"
-                           value={pinnedRoutes.some(route => route.name === selectedRoute) ? selectedRoute : ""}
-                          label="노선 선택"
-                          onChange={handleRouteSelect}
-                        >
-                          {pinnedRoutes.map((route) => (
-                            <MenuItem key={route.id} value={route.name}>
-                              {route.name}
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-
-                      {/* 시간 선택 */}
-                      <FormControl fullWidth sx={{ mt: 2 }}>
-                        <InputLabel id="time-select-label">운행 시간 선택</InputLabel>
-                        <Select
-                          labelId="time-select-label"
-                          value={availableTimes.includes(selectedTime) ? selectedTime : ""}
-                          label="운행 시간 선택"
-                          onChange={(e) => setSelectedTime(e.target.value)}
-                          disabled={!availableTimes.length}
-                        >
-                          {availableTimes.map((time, index) => (
-                            <MenuItem key={index} value={time}>
-                              {time}
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-
-                      <FormControl fullWidth sx={{ mt: 2 }}>
-                        <InputLabel id="day-select-label">운행 요일</InputLabel>
-                        <Select
-                          labelId="day-select-label"
-                          multiple
-                          value={selectedDays}
-                          label="운행 요일 선택"
-                          onChange={(e) => setSelectedDays(e.target.value)}
-                          renderValue={(selected) => selected.join(', ')}
-                        >
-                          {['월', '화', '수', '목', '금'].map((day) => (
-                            <MenuItem key={day} value={day}>
-                              <Checkbox checked={selectedDays.indexOf(day) > -1} />
-                              <ListItemText primary={day} />
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-
-                      <FormControl fullWidth sx={{ mt: 2 }}>
-                        <InputLabel id="hour-select-label">예상 소요 시간 (시간)</InputLabel>
-                        <Select
-                          labelId="hour-select-label"
-                          value={duration}
-                          label="예상 소요시간 선택"
-                          onChange={(e) => setDuration(e.target.value)}
-                        >
-                          {[1, 2, 3].map((hour) => (
-                            <MenuItem key={hour} value={hour}>
-                              {hour}시간
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-
-                  </DialogContent>
-                  <DialogActions>
-                    <Button onClick={handleCloseAddDialog}>취소</Button>
-
-                    <Button
-                      variant="contained"
-                      color="primary"
-                      onClick={handleSaveSchedule}
-                      disabled={!selectedRoute || !selectedTime|| !duration || !selectedDays || selectedDays.length === 0 }
-                      >
-                      완료
-                    </Button>
-                  </DialogActions>
-
-                </Dialog>
-
-                <Dialog open={isHistoryOpen} onClose={() => setIsHistoryOpen(false)} maxWidth="md" fullWidth>
-                  <DialogTitle>{selectedDriver?.name}님의 운행 이력</DialogTitle>
-                  <DialogContent>
-                    {drivingHistory.length > 0 ? (
-                      <Table>
-                        <TableHead>
-                          <TableRow>
-                            <TableCell>노선</TableCell>
-                            <TableCell>날짜</TableCell>
-                            <TableCell>예정 출발 시간</TableCell>
-                            <TableCell>운행 종료 시간</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {drivingHistory.map((record, idx) => (
-                            <TableRow key={idx}>
-                              <TableCell>{record.route}</TableCell>
-                              <TableCell>{record.date}</TableCell>
-                              <TableCell>{record.time}</TableCell>
-                              <TableCell>{record.endTime}</TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    ) : (
-                      <Typography>운행 이력이 없습니다.</Typography>
-                    )}
-                  </DialogContent>
-                  <DialogActions>
-                    <Button onClick={() => setIsHistoryOpen(false)}>닫기</Button>
-                  </DialogActions>
-                </Dialog>
-
-          
+            <SearchBar
+              value={searchKeyword}
+              onChange={(e) => setSearchKeyword(e.target.value)}
+              placeholder="이름으로 검색"
+            />
+            <DriverListTable
+              users={filteredUsers}
+              expandedDriverUid={expandedDriverUid}
+              driverSchedules={driverSchedules}
+              coloredSchedule={coloredSchedule}
+              onTimeClick={handleTimeOpen}
+              onScheduleToggle={handleOpenSchedule}
+              onAddClick={handleOpenAddDialog}
+              onCellClick={(matchedSchedule) => {
+                fetchPinnedRoutes(matchedSchedule.uid).then(() => {
+                  setSelectedDays(matchedSchedule.days);
+                  setSelectedTime(matchedSchedule.time);
+                  setDuration(matchedSchedule.duration);
+                  setSelectedRoute(matchedSchedule.route);
+                  setCurrentTargetUser(matchedSchedule.user);
+                  setIsEditing(true);
+                  setEditingScheduleKey(matchedSchedule.key);
+                  handleRouteSelect({ target: { value: matchedSchedule.route } });
+                  setIsAddDialogOpen(true);
+                });
+              }}
+            />
                 
-            </Box>
+            <DriverScheduleDialog
+              open={isAddDialogOpen}
+              onClose={handleCloseAddDialog}
+              onSave={handleSaveSchedule}
+              pinnedRoutes={pinnedRoutes}
+              availableTimes={availableTimes}
+              selectedRoute={selectedRoute}
+              selectedTime={selectedTime}
+              selectedDays={selectedDays}
+              duration={duration}
+              onChangeRoute={handleRouteSelect}
+              onChangeTime={(e) => setSelectedTime(e.target.value)}
+              onChangeDays={(e) => setSelectedDays(e.target.value)}
+              onChangeDuration={(e) => setDuration(e.target.value)}
+            />
+            <DrivingHistoryDialog
+              open={isHistoryOpen}
+              onClose={() => setIsHistoryOpen(false)}
+              driverName={selectedDriver?.name}
+              historyList={drivingHistory}
+            />
+          </Box>
         </TabPanel>
         <TabPanel value={tabIndex} index={1}>
           <Box sx={{ width: '100%', height: '100%', backgroundColor: '#fff',  }}>
-                <TextField
-                  label="이름으로 검색"
-                  variant="outlined"
-                  size="small"
-                  value={searchKeyword}
-                  onChange={(e) => setSearchKeyword(e.target.value)}
-                  sx={{ width: '500px', mb: 2,  }}
-                />
-          
-                <Table>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>uid</TableCell>
-                      <TableCell>아이디</TableCell>
-                      <TableCell>이름</TableCell>
-                      <TableCell>가입 날짜</TableCell>
-                      <TableCell>경고 횟수</TableCell>
-                      <TableCell>정지</TableCell>
-                      <TableCell>작업</TableCell>
-                      <TableCell>메모</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {filteredUsers.map((user) => (
-                      <TableRow key={user.uid}>
-                        <TableCell>{user.uid}</TableCell>
-                        <TableCell>{user.email}</TableCell>
-                        <TableCell>{user.name}</TableCell>
-                        <TableCell>{user.joinDate}</TableCell>
-                        <TableCell>{user.warningCount ?? 0}</TableCell>
-                        <TableCell>{user.isBanned ? "정지됨" : "X"}</TableCell>
-          
-                        <TableCell>
-                          <IconButton onClick={(e) => handleMenuOpen(e, user)}>
-                            <MoreVertIcon />
-                          </IconButton>
-                          <Menu
-                            anchorEl={anchorEl}
-                            open={anchorUserId === user.uid}
-                            onClose={handleMenuClose}
-                          >
-                            <MenuItem onClick={() => handleUnban(user.uid)}>정지 해제</MenuItem>
-                            <MenuItem onClick={() => { handleOpenReset(user); handleMenuClose(); }}>비밀번호 초기화</MenuItem>
-                            <MenuItem onClick={() => { handleOpenEditDialog(user); handleMenuClose(); }}>회원 수정</MenuItem>
-                            <MenuItem onClick={() => {handleOpenMemoHistory(user);handleMenuClose();}}>메모 보기</MenuItem>
-                          </Menu>
-                        </TableCell>
-          
-                        <TableCell>
-                          <IconButton onClick={() => handleOpenMemo(user)}>
-                            <EditNoteIcon />
-                          </IconButton>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-          
-                <Dialog open={isMemoOpen} onClose={handleCloseMemo}>
-                  <DialogTitle>관리자 메모</DialogTitle>
-                  <DialogContent>
-                    <TextField
-                      label="메모 내용"
-                      multiline
-                      fullWidth
-                      value={memoText}
-                      onChange={(e) => setMemoText(e.target.value)}
-                    />
-                    <FormControlLabel
-                      control={<Checkbox checked={isWarning} onChange={(e) => setIsWarning(e.target.checked)} />}
-                      label="경고 부여"
-                    />
-                    <FormControlLabel
-                      control={<Checkbox checked={isBan} onChange={(e) => setIsBan(e.target.checked)} />}
-                      label="계정 정지"
-                    />
-                  </DialogContent>
-                  <DialogActions>
-                    <Button onClick={handleSubmitMemo} color="primary">확인</Button>
-                    <Button onClick={handleCloseMemo} color="secondary">취소</Button>
-                  </DialogActions>
-                </Dialog>
-          
-                <Dialog open={isMemoHistoryOpen} onClose={() => setIsMemoHistoryOpen(false)} maxWidth="sm" fullWidth>
-                  <DialogTitle>📋 메모 이력</DialogTitle>
-                      <Box sx={{ display: 'flex', gap: 1, mb: 2, px: 3 }}>
-                        <Button variant={memoFilter === "all" ? "contained" : "outlined"} onClick={() => setMemoFilter("all")}>전체</Button>
-                        <Button variant={memoFilter === "warning" ? "contained" : "outlined"} onClick={() => setMemoFilter("warning")}>경고</Button>
-                        <Button variant={memoFilter === "ban" ? "contained" : "outlined"} onClick={() => setMemoFilter("ban")}>정지</Button>
-                      </Box>
-                  <DialogContent>
-                    {selectedMemoList.length === 0 ? (
-                      <Typography>메모 이력이 없습니다.</Typography>
-                    ) : (
-                      <Box>
-                        {filteredMemoList.map((memo, index) => (
-                          <Box key={index}>
-                            <Typography variant="body2" sx={{ mb: 1 }}>
-                              {memo.timestamp} / {memo.writer}
-                            </Typography>
-                            <Paper sx={{ p: 1, mb: 2 }}>
-                              <Typography>{memo.text}</Typography>
-                            </Paper>
-                          </Box>
-                        ))}
-                      </Box>
-                    )}
-                  </DialogContent>
-                  <DialogActions>
-                    <Button onClick={() => setIsMemoHistoryOpen(false)}>닫기</Button>
-                  </DialogActions>
-                </Dialog>
-                <Dialog open={isEditDialogOpen} onClose={() => setIsEditDialogOpen(false)}>
-                  <DialogTitle>회원 정보 수정</DialogTitle>
-                  <DialogContent>
-                    <TextField
-                      margin="dense"
-                      label="이메일"
-                      fullWidth
-                      value={editedEmail}
-                      onChange={(e) => setEditedEmail(e.target.value)}
-                    />
-                    <TextField
-                      margin="dense"
-                      label="이름"
-                      fullWidth
-                      value={editedName}
-                      onChange={(e) => setEditedName(e.target.value)}
-                    />
-                  </DialogContent>
-                  <DialogActions>
-                    <Button onClick={() => setIsEditDialogOpen(false)}>취소</Button>
-                    <Button onClick={async () => {
-                      if (!editingUser) return;
-                      const userRef = ref(realtimeDb, `drivers/${editingUser.uid}`);
-                      await update(userRef, {
-                        email: editedEmail,
-                        name: editedName,
-                      });
-        
-                      setAllUsers((prev) =>
-                        prev.map((u) => u.uid === editingUser.uid ? { ...u, email: editedEmail, name: editedName } : u)
-                      );
-                      setFilteredUsers((prev) =>
-                        prev.map((u) => u.uid === editingUser.uid ? { ...u, email: editedEmail, name: editedName } : u)
-                      );
-          
-                      setIsEditDialogOpen(false);
-                    }} color="primary">확인</Button>
-                  </DialogActions>
-                </Dialog>
-                <Dialog open={isResetOpen} onClose={() => setIsResetOpen(false)}>
-                  <DialogTitle>비밀번호 초기화</DialogTitle>
-                  <DialogContent>
-                    <TextField
-                      fullWidth
-                      label="이메일"
-                      value={resetEmail}
-                      onChange={(e) => setResetEmail(e.target.value)}
-                    />
-                    <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
-                      기본 이메일이 입력되어 있으며, 필요 시 변경 가능합니다.
-                    </Typography>
-                  </DialogContent>
-                  <DialogActions>
-                    <Button onClick={handleSendResetEmail} color="primary">확인</Button>
-                    <Button onClick={() => setIsResetOpen(false)} color="secondary">취소</Button>
-                  </DialogActions>
-                </Dialog>
-              </Box>
+            <SearchBar
+              value={searchKeyword}
+              onChange={(e) => setSearchKeyword(e.target.value)}
+              placeholder="이름으로 검색"
+            />
+            <UserTable
+              users={filteredUsers}
+              anchorEl={anchorEl}
+              anchorUserId={anchorUserId}
+              onMemoClick={handleOpenMemo}
+              onMenuClick={handleMenuOpen}
+              onMenuClose={handleMenuClose}
+              onUnban={handleUnban}
+              onReset={handleOpenReset}
+              onEdit={handleOpenEditDialog}
+              onMemoHistory={handleOpenMemoHistory}
+            />
+            <MemoDialog
+              open={isMemoOpen}
+              memoText={memoText}
+              setMemoText={setMemoText}
+              isWarning={isWarning}
+              setIsWarning={setIsWarning}
+              isBan={isBan}
+              setIsBan={setIsBan}
+              onConfirm={handleSubmitMemo}
+              onCancel={handleCloseMemo}
+            />
+            <MemoHistoryDialog
+              open={isMemoHistoryOpen}
+              onClose={() => setIsMemoHistoryOpen(false)}
+              memoFilter={memoFilter}
+              setMemoFilter={setMemoFilter}
+              memoList={selectedMemoList}
+            />
+            <ResetPasswordDialog
+              open={isResetOpen}
+              email={resetEmail}
+              onChangeEmail={(e) => setResetEmail(e.target.value)}
+              onSendResetEmail={handleSendResetEmail}
+              onClose={() => setIsResetOpen(false)}
+            />
+          </Box>
         </TabPanel>
       </Box>
     </Box>

--- a/refacbus_admin/src/pages/DriverManagement.jsx
+++ b/refacbus_admin/src/pages/DriverManagement.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box,} from '@mui/material';
+import { Box, Typography} from '@mui/material';
 import { ref, get, update, push, set } from "firebase/database";
 import { realtimeDb, auth } from "../firebase";
 import { sendPasswordResetEmail } from "firebase/auth";
@@ -9,9 +9,12 @@ import { TabbedContainer, TabPanel } from '../components/common';
 import { DriverListTable, DriverScheduleDialog, DrivingHistoryDialog, ResetPasswordDialog } from '../components/Driver';
 import { timeSlots, days, getDayIndex } from '../components/Driver/constants';
 import SearchBar from '../components/common/SearchBar';
+import { useAdmin } from '../context/AdminContext';
+import { hasPermission } from '../utils/permissionUtil';
 
 const DriverManagement = () => {
-
+  const admin = useAdmin();
+  if (!admin) return null;
   // 기본 UI 상태 및 탭 변환
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabChange = (event, newValue) => {
@@ -479,6 +482,7 @@ const DriverManagement = () => {
         }}
       >
         <TabPanel value={tabIndex} index={0}>
+          {hasPermission(admin, '기사별 운행 이력') ? (
           <Box sx={{ width: '100%', height: '100%', backgroundColor: '#fff',  }}>
             <SearchBar
               value={searchKeyword}
@@ -530,8 +534,12 @@ const DriverManagement = () => {
               historyList={drivingHistory}
             />
           </Box>
+          ) : (
+          <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+        )}
         </TabPanel>
         <TabPanel value={tabIndex} index={1}>
+          {hasPermission(admin, '기사 계정 관리') ? (
           <Box sx={{ width: '100%', height: '100%', backgroundColor: '#fff',  }}>
             <SearchBar
               value={searchKeyword}
@@ -576,6 +584,9 @@ const DriverManagement = () => {
               onClose={() => setIsResetOpen(false)}
             />
           </Box>
+          ) : (
+          <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+        )}
         </TabPanel>
       </Box>
     </Box>

--- a/refacbus_admin/src/pages/Home.jsx
+++ b/refacbus_admin/src/pages/Home.jsx
@@ -8,8 +8,22 @@ import ReservationManagement from './ReservationManagement';
 import DriverManagement from './DriverManagement.jsx';
 import ManagerManagement from './ManagerManagement.jsx';
 import DashBoard from './DashBoard.jsx';
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { auth } from "../firebase";
 
 function Home() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged((user) => {
+      if (!user) {
+        navigate("/Login", { replace: true });
+      }
+    });
+    return () => unsubscribe();
+  }, []);
+
   const [selectedMenu, setSelectedMenu] = useState('home');
 
   const renderContent = () => {

--- a/refacbus_admin/src/pages/Login.jsx
+++ b/refacbus_admin/src/pages/Login.jsx
@@ -39,39 +39,40 @@ export default function Login() {
         alert("이메일과 비밀번호를 입력해주세요.")
         return
     }
-    
 
-    const fullEmail = `${id}@example.com`
+    // ✅ 이메일 보정
+    const fullEmail = id.includes('@') ? id : `${id}@gmail.com`;
 
-    try{
-        const userCredential = await signInWithEmailAndPassword(auth, fullEmail, password)
-        const uid = userCredential.user.uid;
+    try {
+      const userCredential = await signInWithEmailAndPassword(auth, fullEmail, password);
+      const uid = userCredential.user.uid;
 
-        if (rememberId) {
-             localStorage.setItem("savedId", id);
-        } else {
-            localStorage.removeItem("savedId");
-        }
-        
-        const snapshot = await get(ref(realtimeDb, `admin/${uid}`))
-        if (snapshot.exists()){
-            const userData = snapshot.val()
-            console.log("환영합니다,", userData.name)
-            navigate("/Home");
-        } else {
-            alert("관리자 정보가 존재하지 않습니다.")
-        }
+      if (rememberId) {
+        localStorage.setItem("savedId", id);
+      } else {
+        localStorage.removeItem("savedId");
+      }
+
+      const snapshot = await get(ref(realtimeDb, `admin/${uid}`));
+      if (snapshot.exists()) {
+        const userData = snapshot.val();
+        console.log("환영합니다,", userData.name);
+        navigate("/Home");
+      } else {
+        alert("관리자 정보가 존재하지 않습니다.");
+      }
     } catch (error) {
-        if (error.code === "auth/user-not-found"){
-            alert("존재하지 않는 계정입니다.")
-        } else if (error.code === "auth/wrong-password"){
-            alert("비밀번호를 다시 확인해주세요.")
-        } else {
-            alert("로그인에 실패했습니다.")
-            console.error(error)
-        }
+      if (error.code === "auth/user-not-found") {
+        alert("존재하지 않는 계정입니다.");
+      } else if (error.code === "auth/wrong-password") {
+        alert("비밀번호를 다시 확인해주세요.");
+      } else {
+        alert("로그인에 실패했습니다.");
+        console.error(error);
+      }
     }
   };
+
 
   const handleRegister = () => {
     navigate("/Register");

--- a/refacbus_admin/src/pages/ManagerManagement.jsx
+++ b/refacbus_admin/src/pages/ManagerManagement.jsx
@@ -1,26 +1,39 @@
 import React, { useState } from 'react';
 import {
- IconButton, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Box
+ IconButton, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Box, Typography
 } from '@mui/material';
 import { useEffect } from 'react';
 import { onValue } from 'firebase/database';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import AddIcon from '@mui/icons-material/Add';
-import { push, ref, set, update } from 'firebase/database';
+import { push, ref, set, get, update } from 'firebase/database';
 import { realtimeDb } from '../firebase'; 
 import Manager_Schedule from "../components/Manager/Manager_Schedule";
 import TabbedContainer from '../components/common/TabbedContainer';
 import TabPanel from '../components/common/TabPanel';
 import NoticeFormDialog from '../components/Notice/NoticeFormDialog';
-
+import UserTable from '../components/User/UserTable';
+import SearchBar from '../components/common/SearchBar';
+import MemoDialog from '../components/User/MemoDialog';
+import MemoHistoryDialog from '../components/User/MemoHistoryDialog';
+import UserEditDialog from '../components/User/UserEditDialog';
+import PasswordResetDialog from '../components/User/PasswordResetDialog';
+import dayjs from 'dayjs'; 
+import RoleDialog from '../components/Manager/RoleDialog';
+import { ALL_PERMISSIONS } from "../components/Manager/permissions";
+import { useAdmin } from '../context/AdminContext';
+import { hasPermission } from '../utils/permissionUtil';
 
 const ManagerManagement = () => {
+  const admin = useAdmin();
+  console.log("🧩 admin 상태:", admin);
   //탭 상태
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabChange = (event, newValue) => {
     setTabIndex(newValue);
   };
+  if (!admin) return null;
 
   //공지사항 다이얼로그 관련
   const [open, setOpen] = useState(false);
@@ -74,6 +87,227 @@ const ManagerManagement = () => {
   update(noticeRef, { isPinned: !currentState });
   };
 
+  //검색 및 사용자 목록 상태
+    const [searchKeyword, setSearchKeyword] = useState('');
+    const [filteredUsers, setFilteredUsers] = useState([]);
+    const [allUsers, setAllUsers] = useState([]);
+  
+    //context 메뉴 상태
+    const [anchorEl, setAnchorEl] = useState(null);
+    const [anchorUserId, setAnchorUserId] = useState(null);
+  
+    //메모 다이얼로그
+    const [isMemoOpen, setIsMemoOpen] = useState(false);
+    const [selectedUserForMemo, setSelectedUserForMemo] = useState(null);
+    const [memoText, setMemoText] = useState("");
+    const [isWarning, setIsWarning] = useState(false);
+    const [isBan, setIsBan] = useState(false);
+  
+    //메모 기록 확인
+    const [isMemoHistoryOpen, setIsMemoHistoryOpen] = useState(false);
+    const [selectedMemoList, setSelectedMemoList] = useState([]);
+    const [memoFilter, setMemoFilter] = useState("all");
+  
+    //사용자 정보 수정
+    const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+    const [editingUser, setEditingUser] = useState(null);
+    const [editedEmail, setEditedEmail] = useState("");
+    const [editedName, setEditedName] = useState("");
+  
+    //비밀번호 초기화
+    const [resetEmail, setResetEmail] = useState('');
+    const [isResetOpen, setIsResetOpen] = useState(false);
+    const [targetUser, setTargetUser] = useState(null);
+  
+    //사용자 불러오기
+    useEffect(() => {
+      const fetchUsers = async () => {
+        const snapshot = await get(ref(realtimeDb, "admin"));
+        const usersData = snapshot.val();
+        const usersArray = Object.entries(usersData).map(([uid, value]) => ({
+          uid,
+          ...value,
+        }));
+        
+        setAllUsers(usersArray);  // 슈퍼 계정도 포함
+        setFilteredUsers(usersArray.filter(user => user.name !== "박정원"));
+
+      };
+      fetchUsers();
+    }, []);
+  
+    useEffect(() => {
+      const filtered = allUsers.filter((user) => {
+        const nameMatch = (user.name ?? '').toLowerCase().includes(searchKeyword.toLowerCase());
+        const idWithEmail = user.id?.includes('@') ? user.id : `${user.id}@gmail.com`;
+        const idMatch = idWithEmail.toLowerCase().includes(searchKeyword.toLowerCase());
+        return nameMatch || idMatch;
+      });
+      setFilteredUsers(filtered);
+    }, [searchKeyword, allUsers]);
+  
+  
+    //context 메뉴 관련
+    const handleMenuOpen = (event, user) => {
+      setAnchorEl(event.currentTarget);
+      setAnchorUserId(user.uid);
+    };
+  
+    const handleMenuClose = () => {
+      setAnchorEl(null);
+      setAnchorUserId(null);
+    };
+  
+    //메모 다이얼로그
+    const handleOpenMemo = (user) => {
+      setSelectedUserForMemo(user);
+      setIsMemoOpen(true);
+    };
+  
+    const handleCloseMemo = () => {
+      setSelectedUserForMemo(null);
+      setIsMemoOpen(false);
+      setMemoText("");
+      setIsWarning(false);
+      setIsBan(false);
+    };
+  
+  
+    
+    const handleSubmitMemo = async () => {
+      if (!selectedUserForMemo) return;
+  
+      const userRef = ref(realtimeDb, `admin/${selectedUserForMemo.uid}`);
+      const memoRef = ref(realtimeDb, `admin/${selectedUserForMemo.uid}/memo`);
+  
+      const newMemo = {
+        text: memoText.trim(),
+        timestamp: dayjs().format('YYYY-MM-DD'),
+        writer: '관리자A',
+        type: isBan ? 'ban' : isWarning ? 'warning' : 'note'
+      };
+  
+      await push(memoRef, newMemo);
+  
+      const snapshot = await get(userRef);
+      const existingData = snapshot.val();
+  
+      const updates = {};
+  
+      if (isWarning) {
+        updates.warningCount = (existingData?.warningCount ?? 0) + 1;
+      }
+      if (isBan) {
+        updates.isBanned = true;
+      }
+  
+      if (Object.keys(updates).length > 0) {
+        await update(userRef, updates);
+      }
+  
+      setAllUsers((prev) =>
+        prev.map((u) =>
+          u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
+        )
+      );
+      setFilteredUsers((prev) =>
+        prev.map((u) =>
+          u.uid === selectedUserForMemo.uid ? { ...u, ...updates } : u
+        )
+      );
+  
+      handleCloseMemo();
+    };
+  
+  
+    const handleUnban = async (uid) => {
+      await update(ref(realtimeDb, `admin/${uid}`), { isBanned: false });
+  
+      setAllUsers((prev) =>
+        prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
+      );
+      setFilteredUsers((prev) =>
+        prev.map((u) => (u.uid === uid ? { ...u, isBanned: false } : u))
+      );
+  
+      handleMenuClose();
+    };
+  
+  
+    //메모 히스토리 관련
+    const handleOpenMemoHistory = async (user) => {
+      const memoRef = ref(realtimeDb, `admin/${user.uid}/memo`);
+      const snapshot = await get(memoRef);
+  
+      if (snapshot.exists()) {
+        const memoObject = snapshot.val();
+        const memoArray = Object.values(memoObject);
+  
+        const sorted = memoArray.sort(
+          (a, b) => dayjs(b.timestamp).valueOf() - dayjs(a.timestamp).valueOf()
+        );
+        setSelectedMemoList(sorted);
+      } else {
+        setSelectedMemoList([]);
+      }
+  
+      setIsMemoHistoryOpen(true);
+    };
+  
+    //사용자 정보 수정 관련
+    const handleOpenEditDialog = (user) => {
+      setEditingUser(user);
+      setEditedEmail(user.id ?? "");
+      setEditedName(user.name ?? "");
+      setIsEditDialogOpen(true);
+    };
+  
+    //비밀번호 초기화 관련
+    const handleOpenReset = (user) => {
+      setTargetUser(user);
+      setResetEmail(user.id.includes('@') ? user.id : `${user.id}@gmail.com`);
+
+      setIsResetOpen(true);
+    };
+  
+    const handleSendResetEmail = async () => {
+      try {
+        const emailToSend = resetEmail.includes('@') ? resetEmail.trim() : `${resetEmail.trim()}@gmail.com`;
+        await sendPasswordResetEmail(auth, emailToSend);
+
+        alert("비밀번호 초기화 메일이 전송되었습니다.");
+        setIsResetOpen(false);
+      } catch (error) {
+        alert("이메일 전송 실패: " + error.message);
+      }
+    };
+  
+    const [isRoleDialogOpen, setIsRoleDialogOpen] = useState(false);
+    const [selectedUserForRole, setSelectedUserForRole] = useState(null);
+
+    const handleOpenRoleDialog = async (user) => {
+      if (user.name === "박정원") {
+        const userRef = ref(realtimeDb, `admin/${user.uid}/permissions`);
+        await set(userRef, ALL_PERMISSIONS);
+        alert("슈퍼 계정은 모든 권한이 자동 부여됩니다.");
+        return;
+      }
+
+      setSelectedUserForRole(user);
+      setIsRoleDialogOpen(true);
+    };
+
+    const handleSaveRoles = async (updatedPermissions) => {
+      if (!selectedUserForRole) return;
+
+      const userRef = ref(realtimeDb, `admin/${selectedUserForRole.uid}/permissions`);
+      await set(userRef, updatedPermissions);
+
+      alert("권한이 저장되었습니다.");
+      setIsRoleDialogOpen(false);
+    };
+
+
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -95,11 +329,100 @@ const ManagerManagement = () => {
           maxWidth: 'none',
         }}
       >
-        <TabPanel value={tabIndex} index={0}>관리자 역할 구분</TabPanel>
+        <TabPanel value={tabIndex} index={0}>
+          {hasPermission(admin, '관리자 역할 구분') ? (
+          <Box sx={{ width: '100%', backgroundColor: '#fff', padding: 2 }}>
+            <SearchBar
+              value={searchKeyword}
+              onChange={(e) => setSearchKeyword(e.target.value)}
+              placeholder="이름으로 검색"
+            />
+            <UserTable
+              users={filteredUsers}
+              type="admin"
+              anchorEl={anchorEl}
+              anchorUserId={anchorUserId}
+              onMemoClick={handleOpenMemo}
+              onMenuClick={handleMenuOpen}
+              onMenuClose={handleMenuClose}
+              onUnban={handleUnban}
+              onReset={handleOpenReset}
+              onEdit={handleOpenEditDialog}
+              onMemoHistory={handleOpenMemoHistory}
+              onRoleClick={handleOpenRoleDialog}
+            />
+            <MemoDialog
+              open={isMemoOpen}
+              memoText={memoText}
+              setMemoText={setMemoText}
+              isWarning={isWarning}
+              setIsWarning={setIsWarning}
+              isBan={isBan}
+              setIsBan={setIsBan}
+              onConfirm={handleSubmitMemo}
+              onCancel={handleCloseMemo}
+            />
+            <MemoHistoryDialog
+              open={isMemoHistoryOpen}
+              onClose={() => setIsMemoHistoryOpen(false)}
+              memoFilter={memoFilter}
+              setMemoFilter={setMemoFilter}
+              memoList={selectedMemoList}
+            />
+            <UserEditDialog
+              open={isEditDialogOpen}
+              onClose={() => setIsEditDialogOpen(false)}
+              onConfirm={async () => {
+                if (!editingUser) return;
+                const userRef = ref(realtimeDb, `admin/${editingUser.uid}`);
+                await update(userRef, {
+                  id: editedEmail,
+                  name: editedName,
+                });
+
+                setAllUsers((prev) =>
+                  prev.map((u) => u.uid === editingUser.uid ? { ...u, email: editedEmail, name: editedName } : u)
+                );
+                setFilteredUsers((prev) =>
+                  prev.map((u) => u.uid === editingUser.uid ? { ...u, email: editedEmail, name: editedName } : u)
+                );
+
+                setIsEditDialogOpen(false);
+              }}
+              email={editedEmail}
+              name={editedName}
+              setEmail={setEditedEmail}
+              setName={setEditedName}
+            />
+            <PasswordResetDialog
+              open={isResetOpen}
+              email={resetEmail}
+              setEmail={setResetEmail}
+              onConfirm={handleSendResetEmail}
+              onClose={() => setIsResetOpen(false)}
+            />
+            <RoleDialog
+              open={isRoleDialogOpen}
+              onClose={() => setIsRoleDialogOpen(false)}
+              user={selectedUserForRole}
+              onSave={handleSaveRoles}
+              initialPermissions={selectedUserForRole?.permissions || {}}
+            />
+          </Box>
+          ) : (
+            <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+          )}
+        </TabPanel>
         <TabPanel value={tabIndex} index={1}>
+          {hasPermission(admin, '일정 등록 및 관리') ? (
           <Manager_Schedule />
+          ) : (
+            <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+          )}
         </TabPanel>
         <TabPanel value={tabIndex} index={2}>
+          {hasPermission(admin, '공지사항 등록 및 관리') ? (
+            <>
           <Button
             variant="contained"
             startIcon={<AddIcon />}
@@ -148,6 +471,10 @@ const ManagerManagement = () => {
               </TableBody>
             </Table>
           </TableContainer>
+          </>
+          ) : (
+            <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+          )}
         </TabPanel>
       </Box>
     </Box>

--- a/refacbus_admin/src/pages/ManagerManagement.jsx
+++ b/refacbus_admin/src/pages/ManagerManagement.jsx
@@ -19,6 +19,8 @@ import { realtimeDb } from '../firebase';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
+import Manager_Schedule from "../components/Manager_Schedule";
+
 
 
 const TabPanel = ({ children, value, index }) => {
@@ -110,7 +112,6 @@ const ManagerManagement = () => {
           }}
         >
           <Tab label="관리자 역할 구분" />
-          <Tab label="주요 기능 접근 제한" />
           <Tab label="일정 등록 및 관리" />
           <Tab label="공지사항 등록 및 관리" />
         </Tabs>
@@ -128,9 +129,10 @@ const ManagerManagement = () => {
         }}
       >
         <TabPanel value={tabIndex} index={0}>관리자 역할 구분</TabPanel>
-        <TabPanel value={tabIndex} index={1}>주요 기능 접근 제한</TabPanel>
-        <TabPanel value={tabIndex} index={2}>일정 등록 및 관리</TabPanel>
-        <TabPanel value={tabIndex} index={3}>
+        <TabPanel value={tabIndex} index={1}>
+          <Manager_Schedule />
+        </TabPanel>
+        <TabPanel value={tabIndex} index={2}>
           <Button
             variant="contained"
             startIcon={<AddIcon />}

--- a/refacbus_admin/src/pages/ManagerManagement.jsx
+++ b/refacbus_admin/src/pages/ManagerManagement.jsx
@@ -1,22 +1,14 @@
 import React, { useState } from 'react';
 import {
-  Dialog, DialogTitle, DialogContent, TextField, IconButton, Button, Typography
+ IconButton, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Box
 } from '@mui/material';
 import { useEffect } from 'react';
 import { onValue } from 'firebase/database';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import AddIcon from '@mui/icons-material/Add';
 import { push, ref, set, update } from 'firebase/database';
 import { realtimeDb } from '../firebase'; 
-import Box from '@mui/material/Box';
 import Manager_Schedule from "../components/Manager/Manager_Schedule";
 import TabbedContainer from '../components/common/TabbedContainer';
 import TabPanel from '../components/common/TabPanel';
@@ -24,17 +16,22 @@ import NoticeFormDialog from '../components/Notice/NoticeFormDialog';
 
 
 const ManagerManagement = () => {
+  //탭 상태
   const [tabIndex, setTabIndex] = useState(0);
-  const [open, setOpen] = useState(false);
-  const [title, setTitle] = useState('');
-  const [url, setUrl] = useState('');
-  const [isPinned, setIsPinned] = useState(false);
-  const [notices, setNotices] = useState([]);
-
   const handleTabChange = (event, newValue) => {
     setTabIndex(newValue);
   };
 
+  //공지사항 다이얼로그 관련
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [url, setUrl] = useState('');
+  const [isPinned, setIsPinned] = useState(false);
+
+  //공지사항 목록
+  const [notices, setNotices] = useState([]);
+
+  //공지사항 제출 핸들러
   const handleSubmit = () => {
     const newNotice = {
       title,
@@ -53,6 +50,7 @@ const ManagerManagement = () => {
     setIsPinned(false);
   };
 
+  //공지사항 목록 실시간 불러오기
   useEffect(() => {
     const noticesRef = ref(realtimeDb, 'notices');
     onValue(noticesRef, snapshot => {
@@ -70,6 +68,7 @@ const ManagerManagement = () => {
     });
   }, []);
 
+  //고정여부 토글 핸들러
   const togglePinned = (id, currentState) => {
   const noticeRef = ref(realtimeDb, `notices/${id}`);
   update(noticeRef, { isPinned: !currentState });

--- a/refacbus_admin/src/pages/ManagerManagement.jsx
+++ b/refacbus_admin/src/pages/ManagerManagement.jsx
@@ -17,23 +17,11 @@ import AddIcon from '@mui/icons-material/Add';
 import { push, ref, set, update } from 'firebase/database';
 import { realtimeDb } from '../firebase'; 
 import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
-import Manager_Schedule from "../components/Manager_Schedule";
+import Manager_Schedule from "../components/Manager/Manager_Schedule";
+import TabbedContainer from '../components/common/TabbedContainer';
+import TabPanel from '../components/common/TabPanel';
+import NoticeFormDialog from '../components/Notice/NoticeFormDialog';
 
-
-
-const TabPanel = ({ children, value, index }) => {
-  return (
-    <div hidden={value !== index}>
-      {value === index && (
-        <Box sx={{ p: 3 }}>
-          {children}
-        </Box>
-      )}
-    </div>
-  );
-};
 
 const ManagerManagement = () => {
   const [tabIndex, setTabIndex] = useState(0);
@@ -91,31 +79,11 @@ const ManagerManagement = () => {
   return (
     <Box sx={{ width: '100%' }}>
       
-      {/* 탭 메뉴 */}
-      <Box
-        sx={{
-          backgroundColor: '#fff',
-          py: 1,
-          px: 5,
-          boxShadow: 1,
-        }}
-      >
-        <Tabs
-          value={tabIndex}
-          onChange={handleTabChange}
-          textColor="primary"
-          indicatorColor="primary"
-          variant="standard" 
-          centered             
-          sx={{
-            minWidth: 'fit-content',  
-          }}
-        >
-          <Tab label="관리자 역할 구분" />
-          <Tab label="일정 등록 및 관리" />
-          <Tab label="공지사항 등록 및 관리" />
-        </Tabs>
-      </Box>
+      <TabbedContainer
+          tabIndex={tabIndex}
+          handleTabChange={handleTabChange}
+          labels={["관리자 역할 구분", "일정 등록 및 관리", "공지사항 등록 및 관리"]}
+        />
 
       {/* 회색 박스 본문 */}
       <Box
@@ -142,36 +110,17 @@ const ManagerManagement = () => {
             새 공지사항 등록
           </Button>
 
-          {/* 팝업 다이얼로그 */}
-          <Dialog open={open} onClose={() => setOpen(false)}>
-            <DialogTitle>공지사항 등록</DialogTitle>
-            <DialogContent>
-              <TextField
-                label="제목"
-                fullWidth
-                margin="normal"
-                value={title}
-                onChange={e => setTitle(e.target.value)}
-              />
-              <TextField
-                label="URL"
-                fullWidth
-                margin="normal"
-                value={url}
-                onChange={e => setUrl(e.target.value)}
-              />
-              <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
-                <IconButton onClick={() => setIsPinned(prev => !prev)}>
-                  {isPinned ? <StarIcon color="primary" /> : <StarBorderIcon />}
-                </IconButton>
-                <Typography>{isPinned ? '대시보드에 노출됨' : '공지사항에 등록'}</Typography>
-              </Box>
-              <Box sx={{ mt: 2 }}>
-                <Button variant="contained" onClick={handleSubmit}>등록</Button>
-                <Button onClick={() => setOpen(false)} sx={{ ml: 1 }}>취소</Button>
-              </Box>
-            </DialogContent>
-          </Dialog>
+          <NoticeFormDialog
+            open={open}
+            title={title}
+            setTitle={setTitle}
+            url={url}
+            setUrl={setUrl}
+            isPinned={isPinned}
+            setIsPinned={setIsPinned}
+            onSubmit={handleSubmit}
+            onCancel={() => setOpen(false)}
+          />
           <TableContainer component={Paper}>
             <Table>
               <TableHead>

--- a/refacbus_admin/src/pages/PlaceTimeManagement.jsx
+++ b/refacbus_admin/src/pages/PlaceTimeManagement.jsx
@@ -19,266 +19,263 @@ import SearchBar from '../components/common/SearchBar';
 
 
 const PlaceTimeManagement = () => {
-    const [tabIndex, setTabIndex] = useState(0);
-    const [open, setOpen] = useState(false);
-    const [route, setRoute] = useState('');
-    const [routeName, setRouteName] = useState('');
-    const [isPinned, setIsPinned] = useState(false);
-    const [routeList, setRouteList] = useState([]);
-  
-    const handleTabChange = (event, newValue) => {
-      setTabIndex(newValue);
+
+  // 탭 관련
+  const [tabIndex, setTabIndex] = useState(0);
+  const handleTabChange = (event, newValue) => {
+    setTabIndex(newValue);
+  };
+
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [routeText, setRouteText] = useState("");
+  const [openRouteId, setOpenRouteId] = useState(null);
+
+  //노선 추가/수정 관련
+  const [open, setOpen] = useState(false);
+  const [routeName, setRouteName] = useState('');
+  const [isPinned, setIsPinned] = useState(false);
+  const [routeList, setRouteList] = useState([]);
+  const [selectedRouteInfo, setSelectedRouteInfo] = useState(null); 
+  const [editRouteText, setEditRouteText] = useState('');
+  const [openRouteDialog, setOpenRouteDialog] = useState(false);
+
+  //전체 노선 테이터 상태
+  const [filteredRoutes, setFilteredRoutes] = useState([]);
+  const [allRoutes, setAllRoutes] = useState([]);
+  const [selectedRoute, setSelectedRoute] = useState(null);
+
+  //시간대 관련 상태
+  const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false);
+  const [selectedTimeInfo, setSelectedTimeInfo] = useState(null); 
+  const [openTimeDialog, setOpenTimeDialog] = useState(false);
+  const [editTimeText, setEditTimeText] = useState('');
+
+  //정류장 관련 상태
+  const [isStopDialogOpen, setIsStopDialogOpen] = useState(false);
+  const [openStopEditDialog, setOpenStopEditDialog] = useState(false);
+  const [selectedStopInfo, setSelectedStopInfo] = useState(null);
+  const [editStopText, setEditStopText] = useState('');
+
+  useEffect(() => {
+    const routeListRef = ref(realtimeDb, 'routes');
+    onValue(routeListRef, snapshot => {
+      const data = snapshot.val();
+      if (data) {
+        const list = Object.entries(data).map(([id, item]) => ({
+          id,
+          ...item
+        }));
+        list.sort((a, b) => b.isPinned - a.isPinned);
+        setRouteList(list);
+      } else {
+        setRouteList([]);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const fetchRoutes = async () => {
+    const snapshot = await get(ref(realtimeDb, "routes"));
+    const routesData = snapshot.val();
+    const routesArray = Object.entries(routesData).map(([uid, value]) => ({
+      uid,
+      ...value,
+    }));
+    const pinnedRoutes = routesArray.filter(route => route.isPinned);
+    setAllRoutes(pinnedRoutes);
+    setFilteredRoutes(pinnedRoutes);
+    };
+    fetchRoutes();
+  }, []);
+
+  useEffect(() => {
+    const filtered = allRoutes.filter((route) =>
+      (route.name ?? '').toLowerCase().includes(searchKeyword.toLowerCase())
+    );
+    setFilteredRoutes(filtered);
+  }, [searchKeyword, allRoutes]);
+    
+
+  const [route, setRoute] = useState('');
+  const handleAddRoute = () => {
+    const newRoute = {
+      name: routeName,
+      isPinned,
+      date: new Date().toISOString(),
+      writer: '관리자',
     };
   
-    const handleAddRoute = () => {
-      const newRoute = {
-        name: routeName,
-        isPinned,
-        date: new Date().toISOString(),
-        writer: '관리자',
-      };
-  
-      const newRef = push(ref(realtimeDb, 'routes'));
-      set(newRef, newRoute);
-  
-      setOpen(false);
-      setRoute('');
-      setIsPinned(false);
-    };
-  
-    useEffect(() => {
-      const routeListRef = ref(realtimeDb, 'routes');
-      onValue(routeListRef, snapshot => {
-        const data = snapshot.val();
-        if (data) {
-          const list = Object.entries(data).map(([id, item]) => ({
-            id,
-            ...item
-          }));
-          list.sort((a, b) => b.isPinned - a.isPinned);
-          setRouteList(list);
-        } else {
-          setRouteList([]);
-        }
-      });
-    }, []);
-  
-    const togglePinned = (id, currentState) => {
+    const newRef = push(ref(realtimeDb, 'routes'));
+    set(newRef, newRoute);
+
+    setOpen(false);
+    setRoute('');
+    setIsPinned(false);
+  };
+
+  const togglePinned = (id, currentState) => {
     const routeRef = ref(realtimeDb, `routes/${id}`);
     update(routeRef, { isPinned: !currentState });
-    };
+  };
 
-    const [searchKeyword, setSearchKeyword] = useState('');
-    const [filteredRoutes, setFilteredRoutes] = useState([]);
-    const [allRoutes, setAllRoutes] = useState([]);
-    const [selectedRoute, setSelectedRoute] = useState(null);
-    const [routeText, setRouteText] = useState("");
-    const [openRouteId, setOpenRouteId] = useState(null);
-    const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false);
-  const [isStopDialogOpen, setIsStopDialogOpen] = useState(false);
+  const handleTimeOpen = (route) => {
+    setSelectedRoute(route);
+    setTimeout(() => setIsTimeDialogOpen(true), 0);
+  };
 
+  const handleStopOpen = (route) => {
+    console.log("🧪 handleStopOpen에서 받은 route:", route);
+    setSelectedRoute(route);
+    setTimeout(() => setIsStopDialogOpen(true), 0);
+  };
 
-      useEffect(() => {
-        const fetchRoutes = async () => {
-          const snapshot = await get(ref(realtimeDb, "routes"));
-          const routesData = snapshot.val();
-          const routesArray = Object.entries(routesData).map(([uid, value]) => ({
-            uid,
-            ...value,
-          }));
-          const pinnedRoutes = routesArray.filter(route => route.isPinned);
-          setAllRoutes(pinnedRoutes);
-          setFilteredRoutes(pinnedRoutes);
-        };
-        fetchRoutes();
-      }, []);
-    
-      useEffect(() => {
-        const filtered = allRoutes.filter((route) =>
-          (route.name ?? '').toLowerCase().includes(searchKeyword.toLowerCase())
-        );
-        setFilteredRoutes(filtered);
-      }, [searchKeyword, allRoutes]);
-    
-      const handleTimeOpen = (route) => {
-        setSelectedRoute(route);
-        // 상태 설정 후 다음 프레임에서 실행
-        setTimeout(() => setIsTimeDialogOpen(true), 0);
-      };
+  const updateRoutes = (key, value) => {
+    setAllRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === selectedRoute.uid ? { ...route, [key]: value } : route
+      )
+    );
+    setFilteredRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === selectedRoute.uid ? { ...route, [key]: value } : route
+      )
+    );
+  };
 
-      const updateRoutes = (key, value) => {
-        setAllRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === selectedRoute.uid ? { ...route, [key]: value } : route
-          )
-        );
-        setFilteredRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === selectedRoute.uid ? { ...route, [key]: value } : route
-          )
-        );
-      };
-      
-      const handleSubmitTime = async () => {
-        if (!selectedRoute || !routeText.trim()) return;
-        const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/times`);
-        await push(dataRef, routeText.trim());
+  const handleSubmitTime = async () => {
+    if (!selectedRoute || !routeText.trim()) return;
+    const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/times`);
+    await push(dataRef, routeText.trim());
 
-        const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRoute.uid}`));
-        const updatedData = updatedSnapshot.val();
+    const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRoute.uid}`));
+    const updatedData = updatedSnapshot.val();
         
 
-        updateRoutes('times', updatedData.times);
-        setIsTimeDialogOpen(false);
-        setRouteText('');
-        setSelectedRoute(null);
-      };
+    updateRoutes('times', updatedData.times);
+    setIsTimeDialogOpen(false);
+    setRouteText('');
+    setSelectedRoute(null);
+  };
 
-      const handleSubmitStop = async () => {
-        if (!selectedRoute || !routeText.trim()) return;
-        const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/stops`);
-        await push(dataRef, routeText.trim());
+  const handleUpdateTime = async () => {
+    if (!selectedTimeInfo) return;
+    const { routeId, timeId } = selectedTimeInfo;
+    await set(ref(realtimeDb, `routes/${routeId}/times/${timeId}`), editTimeText); 
 
-        const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRoute.uid}`));
-        const updatedData = updatedSnapshot.val();
+    const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+    const updatedData = updatedSnapshot.val();
 
-        updateRoutes('stops', updatedData.stops);
-        setIsStopDialogOpen(false);
-        setRouteText('');
-        setSelectedRoute(null);
-      };
+    setAllRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, times: updatedData.times } : route
+      )
+    );
+    setFilteredRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, times: updatedData.times } : route
+      )
+    );
+    setOpenTimeDialog(false);
+  };
 
-      
-      const handleUpdateTime = async () => {
-        if (!selectedTimeInfo) return;
-        const { routeId, timeId } = selectedTimeInfo;
-        await set(ref(realtimeDb, `routes/${routeId}/times/${timeId}`), editTimeText); 
+  const handleDeleteTime = async () => {
+    if (!selectedTimeInfo) return;
+    const { routeId, timeId } = selectedTimeInfo;
 
-        const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-        const updatedData = updatedSnapshot.val();
+    await update(ref(realtimeDb, `routes/${routeId}/times`), {
+      [timeId]: null
+    });
 
-        setAllRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, times: updatedData.times } : route
-          )
-        );
-        setFilteredRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, times: updatedData.times } : route
-          )
-        );
-        setOpenTimeDialog(false);
-      };
+    const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+    const updatedData = snapshot.val()
 
-      const handleDeleteTime = async () => {
-        if (!selectedTimeInfo) return;
-        const { routeId, timeId } = selectedTimeInfo;
+    setAllRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, times: updatedData.times } : route
+      )
+    );
+    setFilteredRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, times: updatedData.times } : route
+      )
+    )
+    setOpenTimeDialog(false);
+  };
 
-        await update(ref(realtimeDb, `routes/${routeId}/times`), {
-          [timeId]: null
-        });
+  const handleSubmitStop = async () => {
+    if (!selectedRoute || !routeText.trim()) return;
+    const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/stops`);
+    await push(dataRef, routeText.trim());
 
-        const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-        const updatedData = snapshot.val();
+    const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRoute.uid}`));
+    const updatedData = updatedSnapshot.val();
 
-        setAllRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, times: updatedData.times } : route
-          )
-        );
-        setFilteredRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, times: updatedData.times } : route
-          )
-        );
+    updateRoutes('stops', updatedData.stops);
+    setIsStopDialogOpen(false);
+    setRouteText('');
+    setSelectedRoute(null);
+  };
 
-        setOpenTimeDialog(false);
-      };
+  const handleUpdateStop = async () => {
+    if (!selectedStopInfo) return;
+    const { routeId, stopId } = selectedStopInfo;
 
-      const handleUpdateStop = async () => {
-        if (!selectedStopInfo) return;
-        const { routeId, stopId } = selectedStopInfo;
+    await set(ref(realtimeDb, `routes/${routeId}/stops/${stopId}`), editStopText);
 
-        await set(ref(realtimeDb, `routes/${routeId}/stops/${stopId}`), editStopText);
+    const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+    const updatedData = snapshot.val();
 
-        const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-        const updatedData = snapshot.val();
+    setAllRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+      )
+    );
+    setFilteredRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+      )
+    );
 
-        setAllRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-          )
-        );
-        setFilteredRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-          )
-        );
+    setOpenStopEditDialog(false);
+  };
 
-        setOpenStopEditDialog(false);
-      };
+  const handleDeleteStop = async () => {
+    if (!selectedStopInfo) return;
+    const { routeId, stopId } = selectedStopInfo;
 
-      const handleDeleteStop = async () => {
-        if (!selectedStopInfo) return;
-        const { routeId, stopId } = selectedStopInfo;
+    await update(ref(realtimeDb, `routes/${routeId}/stops`), {
+      [stopId]: null
+    });
 
-        await update(ref(realtimeDb, `routes/${routeId}/stops`), {
-          [stopId]: null
-        });
+    const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+    const updatedData = snapshot.val();
 
-        const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-        const updatedData = snapshot.val();
+    setAllRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+      )
+    );
+    setFilteredRoutes((prev) =>
+      prev.map((route) =>
+        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+      )
+    );
 
-        setAllRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-          )
-        );
-        setFilteredRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-          )
-        );
+    setOpenStopEditDialog(false);
+  };
 
-        setOpenStopEditDialog(false);
-      };
+  const handleEditTimeClick = (routeId, timeId, timeValue) => {
+    setSelectedTimeInfo({ routeId, itemId: timeId, value: timeValue });
+    setEditTimeText(timeValue);
+    setOpenTimeDialog(true);
+  };
 
-
-      const [selectedTimeInfo, setSelectedTimeInfo] = useState(null); 
-      const [openTimeDialog, setOpenTimeDialog] = useState(false);
-      const [editTimeText, setEditTimeText] = useState('');
-
-      
-      const [openStopEditDialog, setOpenStopEditDialog] = useState(false);
-      const [selectedStopInfo, setSelectedStopInfo] = useState(null);
-      const [editStopText, setEditStopText] = useState('');
-
-
-      const handleStopOpen = (route) => {
-        console.log("🧪 handleStopOpen에서 받은 route:", route);
-        setSelectedRoute(route);
-        // 상태 설정 후 다음 프레임에서 실행
-        setTimeout(() => setIsStopDialogOpen(true), 0);
-      };
-
-
-      const [selectedRouteInfo, setSelectedRouteInfo] = useState(null); 
-      const [editRouteText, setEditRouteText] = useState('');
-      const [openRouteDialog, setOpenRouteDialog] = useState(false);
-
-      const handleEditTimeClick = (routeId, timeId, timeValue) => {
-        setSelectedTimeInfo({ routeId, itemId: timeId, value: timeValue });
-        setEditTimeText(timeValue);
-        setOpenTimeDialog(true);
-      };
-
-      const handleEditStopClick = (routeId, stopId, stopName) => {
-        setSelectedStopInfo({ routeId, itemId: stopId, value: stopName });
-        setEditStopText(stopName);
-        setOpenStopEditDialog(true);
-      };
-
-    
+  const handleEditStopClick = (routeId, stopId, stopName) => {
+    setSelectedStopInfo({ routeId, itemId: stopId, value: stopName });
+    setEditStopText(stopName);
+    setOpenStopEditDialog(true);
+  };
+  
 
   return (
     <Box sx={{ width: '100%' }}>

--- a/refacbus_admin/src/pages/PlaceTimeManagement.jsx
+++ b/refacbus_admin/src/pages/PlaceTimeManagement.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useEffect } from 'react';
 import { onValue } from 'firebase/database';import StarIcon from '@mui/icons-material/Star';
 import AddIcon from '@mui/icons-material/Add';
-import { TextField, Box, Button, } from '@mui/material';
+import { Typography, Box, Button, } from '@mui/material';
 import { ref, get, update, push, set } from "firebase/database";
 import { realtimeDb, auth } from "../firebase";
 import TabbedContainer from '../components/common/TabbedContainer';
@@ -15,11 +15,14 @@ import StopEditDialog from '../components/PlaceTime/StopEditDialog';
 import RouteListTable from '../components/PlaceTime/RouteListTable';
 import TimeStopTable from '../components/PlaceTime/TimeStopTable';
 import SearchBar from '../components/common/SearchBar';
+import { useAdmin } from '../context/AdminContext';
+import { hasPermission } from '../utils/permissionUtil';
 
 
 
 const PlaceTimeManagement = () => {
-
+  const admin = useAdmin();
+  if (!admin) return null;
   // 탭 관련
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabChange = (event, newValue) => {
@@ -297,7 +300,8 @@ const PlaceTimeManagement = () => {
         }}
       >
         <TabPanel value={tabIndex} index={0}>
-          
+          {hasPermission(admin, '노선 추가 및 삭제') ? (
+          <Box>
           <Button
             variant="contained"
             startIcon={<AddIcon />}
@@ -306,8 +310,6 @@ const PlaceTimeManagement = () => {
               >
             새 노선 등록
           </Button>
-          
-          
           <RouteAddDialog
             open={open}
             routeName={routeName}
@@ -327,8 +329,13 @@ const PlaceTimeManagement = () => {
             }}
             onTogglePinned={(id, currentPinned) => togglePinned(id, currentPinned)}
           />       
+          </Box>
+          ) : (
+          <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+        )}
         </TabPanel>
         <TabPanel value={tabIndex} index={1}>
+          {hasPermission(admin, '노선 시간대 설정 및 관리') ? (
           <Box sx={{ width: '100%', backgroundColor: '#fff', padding: 2 }}>
             <SearchBar
               value={searchKeyword}
@@ -370,8 +377,12 @@ const PlaceTimeManagement = () => {
             />
 
           </Box>
+          ) : (
+          <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+        )}
         </TabPanel>
         <TabPanel value={tabIndex} index={2}>
+          {hasPermission(admin, '노선 정류장 설정 및 관리') ? (
           <Box sx={{ width: '100%', backgroundColor: '#fff', padding: 2 }}>
             <SearchBar
               value={searchKeyword}
@@ -412,6 +423,9 @@ const PlaceTimeManagement = () => {
             />
 
           </Box>
+          ) : (
+          <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+        )}
         </TabPanel>
       </Box>
     </Box>

--- a/refacbus_admin/src/pages/PlaceTimeManagement.jsx
+++ b/refacbus_admin/src/pages/PlaceTimeManagement.jsx
@@ -1,37 +1,28 @@
 import React, { useState } from 'react';
 import { useEffect } from 'react';
 import { onValue } from 'firebase/database';import StarIcon from '@mui/icons-material/Star';
-import StarBorderIcon from '@mui/icons-material/StarBorder';
 import AddIcon from '@mui/icons-material/Add';
-import {
-  TextField, Box, Table, TableHead, TableCell, TableRow, TableBody,
-  Tab, Tabs, Dialog, DialogTitle, DialogContent, DialogActions,
-  TableContainer, Button, Typography, Paper
-} from '@mui/material';
+import { TextField, Box, Button, } from '@mui/material';
 import { ref, get, update, push, set } from "firebase/database";
 import { realtimeDb, auth } from "../firebase";
-import IconButton from "@mui/material/IconButton";
-import AccessTimeIcon from "@mui/icons-material/AccessTime";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import dayjs from "dayjs"; 
+import TabbedContainer from '../components/common/TabbedContainer';
+import TabPanel from '../components/common/TabPanel'; // 공통 컴포넌트로 분리해둔 것
+import RouteAddDialog from '../components/PlaceTime/RouteAddDialog';
+import TimeAddDialog from '../components/PlaceTime/TimeAddDialog';
+import TimeEditDialog from '../components/PlaceTime/TimeEditDialog';
+import StopAddDialog from '../components/PlaceTime/StopAddDialog';
+import StopEditDialog from '../components/PlaceTime/StopEditDialog';
+import RouteListTable from '../components/PlaceTime/RouteListTable';
+import TimeStopTable from '../components/PlaceTime/TimeStopTable';
+import SearchBar from '../components/common/SearchBar';
 
-const TabPanel = ({ children, value, index }) => {
-  return (
-    <div hidden={value !== index}>
-      {value === index && (
-        <Box sx={{ p: 3 }}>
-          {children}
-        </Box>
-      )}
-    </div>
-  );
-};
+
 
 const PlaceTimeManagement = () => {
     const [tabIndex, setTabIndex] = useState(0);
     const [open, setOpen] = useState(false);
     const [route, setRoute] = useState('');
+    const [routeName, setRouteName] = useState('');
     const [isPinned, setIsPinned] = useState(false);
     const [routeList, setRouteList] = useState([]);
   
@@ -39,9 +30,9 @@ const PlaceTimeManagement = () => {
       setTabIndex(newValue);
     };
   
-    const handleSubmit = () => {
+    const handleAddRoute = () => {
       const newRoute = {
-        name: route,
+        name: routeName,
         isPinned,
         date: new Date().toISOString(),
         writer: '관리자',
@@ -80,10 +71,12 @@ const PlaceTimeManagement = () => {
     const [searchKeyword, setSearchKeyword] = useState('');
     const [filteredRoutes, setFilteredRoutes] = useState([]);
     const [allRoutes, setAllRoutes] = useState([]);
-    const [isRouteOpen, setIsRouteOpen] = useState(false);
     const [selectedRoute, setSelectedRoute] = useState(null);
     const [routeText, setRouteText] = useState("");
     const [openRouteId, setOpenRouteId] = useState(null);
+    const [isTimeDialogOpen, setIsTimeDialogOpen] = useState(false);
+  const [isStopDialogOpen, setIsStopDialogOpen] = useState(false);
+
 
       useEffect(() => {
         const fetchRoutes = async () => {
@@ -107,99 +100,194 @@ const PlaceTimeManagement = () => {
         setFilteredRoutes(filtered);
       }, [searchKeyword, allRoutes]);
     
-      const handleMenuOpen = (event, route) => {
-        setSelectedRoute(route); 
-        setIsRouteOpen(true);
+      const handleTimeOpen = (route) => {
+        setSelectedRoute(route);
+        // 상태 설정 후 다음 프레임에서 실행
+        setTimeout(() => setIsTimeDialogOpen(true), 0);
       };
-    
-      const handleCloseMemo = () => {
-        setSelectedRoute(null);
-        setIsRouteOpen(false);
-        setRouteText("");
-      };
-    
-      const handleSubmitMemo = async () => {
-        if (!selectedRoute || !routeText.trim()) return;
 
-        const targetKey = tabIndex === 1 ? "times" : "stops";
-        const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/${targetKey}`);
+      const updateRoutes = (key, value) => {
+        setAllRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === selectedRoute.uid ? { ...route, [key]: value } : route
+          )
+        );
+        setFilteredRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === selectedRoute.uid ? { ...route, [key]: value } : route
+          )
+        );
+      };
+      
+      const handleSubmitTime = async () => {
+        if (!selectedRoute || !routeText.trim()) return;
+        const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/times`);
+        await push(dataRef, routeText.trim());
+
+        const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRoute.uid}`));
+        const updatedData = updatedSnapshot.val();
+        
+
+        updateRoutes('times', updatedData.times);
+        setIsTimeDialogOpen(false);
+        setRouteText('');
+        setSelectedRoute(null);
+      };
+
+      const handleSubmitStop = async () => {
+        if (!selectedRoute || !routeText.trim()) return;
+        const dataRef = ref(realtimeDb, `routes/${selectedRoute.uid}/stops`);
         await push(dataRef, routeText.trim());
 
         const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRoute.uid}`));
         const updatedData = updatedSnapshot.val();
 
-        setAllRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === selectedRoute.uid ? { ...route, [targetKey]: updatedData[targetKey] } : route
-          )
-        );
-        setFilteredRoutes((prev) =>
-          prev.map((route) =>
-            route.uid === selectedRoute.uid ? { ...route, [targetKey]: updatedData[targetKey] } : route
-          )
-        );
-
-        setIsRouteOpen(false);
+        updateRoutes('stops', updatedData.stops);
+        setIsStopDialogOpen(false);
         setRouteText('');
         setSelectedRoute(null);
       };
 
-      const handleToggleTimes = (uid) => {
-      setOpenRouteId(prev => (prev === uid ? null : uid));
+      
+      const handleUpdateTime = async () => {
+        if (!selectedTimeInfo) return;
+        const { routeId, timeId } = selectedTimeInfo;
+        await set(ref(realtimeDb, `routes/${routeId}/times/${timeId}`), editTimeText); 
+
+        const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+        const updatedData = updatedSnapshot.val();
+
+        setAllRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, times: updatedData.times } : route
+          )
+        );
+        setFilteredRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, times: updatedData.times } : route
+          )
+        );
+        setOpenTimeDialog(false);
       };
+
+      const handleDeleteTime = async () => {
+        if (!selectedTimeInfo) return;
+        const { routeId, timeId } = selectedTimeInfo;
+
+        await update(ref(realtimeDb, `routes/${routeId}/times`), {
+          [timeId]: null
+        });
+
+        const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+        const updatedData = snapshot.val();
+
+        setAllRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, times: updatedData.times } : route
+          )
+        );
+        setFilteredRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, times: updatedData.times } : route
+          )
+        );
+
+        setOpenTimeDialog(false);
+      };
+
+      const handleUpdateStop = async () => {
+        if (!selectedStopInfo) return;
+        const { routeId, stopId } = selectedStopInfo;
+
+        await set(ref(realtimeDb, `routes/${routeId}/stops/${stopId}`), editStopText);
+
+        const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+        const updatedData = snapshot.val();
+
+        setAllRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+          )
+        );
+        setFilteredRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+          )
+        );
+
+        setOpenStopEditDialog(false);
+      };
+
+      const handleDeleteStop = async () => {
+        if (!selectedStopInfo) return;
+        const { routeId, stopId } = selectedStopInfo;
+
+        await update(ref(realtimeDb, `routes/${routeId}/stops`), {
+          [stopId]: null
+        });
+
+        const snapshot = await get(ref(realtimeDb, `routes/${routeId}`));
+        const updatedData = snapshot.val();
+
+        setAllRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+          )
+        );
+        setFilteredRoutes((prev) =>
+          prev.map((route) =>
+            route.uid === routeId ? { ...route, stops: updatedData.stops } : route
+          )
+        );
+
+        setOpenStopEditDialog(false);
+      };
+
 
       const [selectedTimeInfo, setSelectedTimeInfo] = useState(null); 
       const [openTimeDialog, setOpenTimeDialog] = useState(false);
       const [editTimeText, setEditTimeText] = useState('');
 
       
-      const [isStopDialogOpen, setIsStopDialogOpen] = useState(false);
-      const [selectedRouteForStop, setSelectedRouteForStop] = useState(null);
       const [openStopEditDialog, setOpenStopEditDialog] = useState(false);
       const [selectedStopInfo, setSelectedStopInfo] = useState(null);
       const [editStopText, setEditStopText] = useState('');
 
 
-      const handleStopOpen = (event, route) => {
-        setSelectedRouteForStop(route);  
-        setIsStopDialogOpen(true); 
+      const handleStopOpen = (route) => {
+        console.log("🧪 handleStopOpen에서 받은 route:", route);
+        setSelectedRoute(route);
+        // 상태 설정 후 다음 프레임에서 실행
+        setTimeout(() => setIsStopDialogOpen(true), 0);
       };
+
 
       const [selectedRouteInfo, setSelectedRouteInfo] = useState(null); 
       const [editRouteText, setEditRouteText] = useState('');
       const [openRouteDialog, setOpenRouteDialog] = useState(false);
 
+      const handleEditTimeClick = (routeId, timeId, timeValue) => {
+        setSelectedTimeInfo({ routeId, itemId: timeId, value: timeValue });
+        setEditTimeText(timeValue);
+        setOpenTimeDialog(true);
+      };
+
+      const handleEditStopClick = (routeId, stopId, stopName) => {
+        setSelectedStopInfo({ routeId, itemId: stopId, value: stopName });
+        setEditStopText(stopName);
+        setOpenStopEditDialog(true);
+      };
 
     
 
   return (
     <Box sx={{ width: '100%' }}>
       
-      {/* 탭 메뉴 */}
-      <Box
-        sx={{
-          backgroundColor: '#fff',
-          py: 1,
-          px: 5,
-          boxShadow: 1,
-        }}
-      >
-        <Tabs
-          value={tabIndex}
-          onChange={handleTabChange}
-          textColor="primary"
-          indicatorColor="primary"
-          variant="standard"
-          centered             
-          sx={{
-            minWidth: 'fit-content',  
-          }}
-        >
-          <Tab label="노선 추가 / 삭제" />
-          <Tab label="노선 시간대 설정 및 관리" />
-          <Tab label="노선 정류장 설정 및 관리" />
-        </Tabs>
-      </Box>
+      <TabbedContainer
+          tabIndex={tabIndex}
+          handleTabChange={handleTabChange}
+          labels={["노선 추가 / 삭제", "노선 시간대 설정 및 관리", "노선 정류장 설정 및 관리"]}
+        />
 
       {/* 회색 박스 본문 */}
       <Box
@@ -223,435 +311,108 @@ const PlaceTimeManagement = () => {
           </Button>
           
           
-          {/* 팝업 다이얼로그 */}
-          <Dialog open={open} onClose={() => setOpen(false)}>
-            <DialogTitle>노선 등록</DialogTitle>
-              <DialogContent>
-                <TextField
-                  label="노선"
-                  fullWidth
-                  margin="normal"
-                  value={route}
-                  onChange={e => setRoute(e.target.value)}
-                  />
-                
-                <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
-                  
-                  <IconButton onClick={() => setIsPinned(prev => !prev)}>
-                    {isPinned ? <StarIcon color="primary" /> : <StarBorderIcon />}
-                  </IconButton>
-                  <Typography>{isPinned ? '' : '현사용 노선에 등록'}</Typography>
-                    </Box>
-                      <Box sx={{ mt: 2 }}>
-                        <Button variant="contained" onClick={handleSubmit}>등록</Button>
-                        <Button onClick={() => setOpen(false)} sx={{ ml: 1 }}>취소</Button>
-                      </Box>
-                    </DialogContent>
-                    </Dialog>
-                    <TableContainer component={Paper}>
-                      <Table>
-                        <TableHead>
-                          <TableRow>
-                            <TableCell style={{ width: "50%" }}>노선</TableCell>
-                            <TableCell style={{ width: "40%" }}>등록 날짜</TableCell>
-                            <TableCell style={{ width: "10%" }}>고정</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {routeList.map((item) => (
-                            <TableRow key={item.id}>
-                              <TableCell>
-                                <a style={{ cursor: 'pointer' }}
-                                  onClick={() => {
-                                    setSelectedRouteInfo({ id: item.id, name: item.name });
-                                    setEditRouteText(item.name);
-                                    setOpenRouteDialog(true);
-                                  }}>
-                                  {item.name}
-                                </a>
-                              </TableCell>
-                              <TableCell>{new Date(item.date).toLocaleDateString()}</TableCell>
-                              <TableCell>
-                                <IconButton onClick={() => togglePinned(item.id, item.isPinned)}>
-                                  {item.isPinned ? <StarIcon color="warning" /> : <StarBorderIcon />}
-                                </IconButton>
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                      <Dialog open={openRouteDialog} onClose={() => setOpenRouteDialog(false)}>
-                        <DialogTitle>노선명 수정 / 삭제</DialogTitle>
-                        <DialogContent>
-                          <TextField
-                            label="노선명"
-                            fullWidth
-                            value={editRouteText}
-                            onChange={(e) => setEditRouteText(e.target.value)}
-                          />
-                        </DialogContent>
-                        <DialogActions>
-                          <Button
-                            color="error"
-                            onClick={async () => {
-                              if (!selectedRouteInfo) return;
-                              await remove(ref(realtimeDb, `routes/${selectedRouteInfo.id}`));
-                              setRouteList((prev) => prev.filter((r) => r.id !== selectedRouteInfo.id));
-                              setOpenRouteDialog(false);
-                            }}
-                          >
-                            삭제
-                          </Button>
-                          <Button
-                            color="primary"
-                            onClick={async () => {
-                              if (!selectedRouteInfo) return;
-                              await set(ref(realtimeDb, `routes/${selectedRouteInfo.id}/name`), editRouteText);
-                              const updatedSnapshot = await get(ref(realtimeDb, `routes/${selectedRouteInfo.id}`));
-                              const updatedData = updatedSnapshot.val();
-                              setRouteList((prev) =>
-                                prev.map((r) => r.id === selectedRouteInfo.id ? { ...r, name: updatedData.name } : r)
-                              );
-                              setOpenRouteDialog(false);
-                            }}
-                          >
-                            수정
-                          </Button>
-                        </DialogActions>
-                      </Dialog>
+          <RouteAddDialog
+            open={open}
+            routeName={routeName}
+            isPinned={isPinned}
+            onChangeName={(e) => setRouteName(e.target.value)}
+            onChangePinned={(e) => setIsPinned(e.target.checked)}
+            onClose={() => setOpen(false)}
+            onSubmit={handleAddRoute}
+          />
 
-                    </TableContainer>
+          <RouteListTable
+            routeList={routeList}
+            onClickRoute={(item) => {
+              setSelectedRouteInfo({ id: item.id, name: item.name });
+              setEditRouteText(item.name);
+              setOpenRouteDialog(true);
+            }}
+            onTogglePinned={(id, currentPinned) => togglePinned(id, currentPinned)}
+          />       
         </TabPanel>
         <TabPanel value={tabIndex} index={1}>
           <Box sx={{ width: '100%', backgroundColor: '#fff', padding: 2 }}>
-            <TextField
-              label="노선으로 검색"
-              variant="outlined"
-              size="small"
+            <SearchBar
               value={searchKeyword}
               onChange={(e) => setSearchKeyword(e.target.value)}
-              sx={{ width: '500px', mb: 2 }}
+              placeholder="노선으로 검색"
             />
 
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell style={{ width: "40%" }}>노선명</TableCell>
-                  <TableCell style={{ width: "20%" }}>일일 운행 회수</TableCell>
-                  <TableCell style={{ width: "20%" }}>시간대 추가</TableCell>
-                  <TableCell style={{ width: "20%" }}>시간대 목록</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {filteredRoutes.map((route) => (
-                  <React.Fragment key={route.uid}>
-                    <TableRow key={route.uid}>
-                      <TableCell>{route.name}</TableCell>
-                      <TableCell>{route.times ? Object.keys(route.times).length + '회' : '0회'}</TableCell>
-                      <TableCell>
-                        <IconButton onClick={(e) => handleMenuOpen(e, route)}>
-                          <AccessTimeIcon />
-                        </IconButton>
-                      </TableCell>
-                      <TableCell>
-                        <IconButton onClick={() => handleToggleTimes(route.uid)}>
-                          {openRouteId === route.uid ? (
-                            <ExpandLessIcon />
-                          ) : (
-                            <ExpandMoreIcon />
-                          )}
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  {openRouteId === route.uid && (
-                    <TableRow>
-                      <TableCell colSpan={4}>
-                        <Typography sx={{ mb: 1 }}>🚌 시간대 목록</Typography>
-                        {route.times
-                          ? (
-                            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                            {Object.entries(route.times).map(([timeId, timeValue]) => (
-                              <Box
-                                key={timeId}
-                                onClick={() => {
-                                  setSelectedTimeInfo({ routeId: route.uid, timeId, value: timeValue });
-                                  setEditTimeText(timeValue);
-                                  setOpenTimeDialog(true);
-                                }}
-                                sx={{
-                                  cursor: 'pointer',
-                                  width: '19%',
-                                  backgroundColor: '#e3f2fd',
-                                  padding: '8px',
-                                  borderRadius: '4px',
-                                  textAlign: 'center',
-                                  boxShadow: 1,
-                                }}
-                              >
-                                {timeValue}
-                              </Box>
-                            ))}
-
-                          </Box>
-                        ) : (
-                          <Typography color="text.secondary">등록된 시간대가 없습니다</Typography>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </React.Fragment>
-                ))}
-              </TableBody>
-            </Table>
-
-            <Dialog open={isRouteOpen} onClose={handleCloseMemo}>
-              <DialogTitle>시간대 추가</DialogTitle>
-              <DialogContent>
-                <TextField
-                  label="시간 입력"
-                  multiline
-                  fullWidth
-                  value={routeText}
-                  onChange={(e) => setRouteText(e.target.value)}
-                />
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={handleSubmitMemo} color="primary">확인</Button>
-                <Button onClick={handleCloseMemo} color="secondary">취소</Button>
-              </DialogActions>
-            </Dialog>
+            <TimeStopTable
+              filteredRoutes={filteredRoutes}
+              openRouteId={openRouteId}
+              setOpenRouteId={setOpenRouteId}
+              itemKey="times"
+              itemLabel="시간대"
+              onAddClick={handleTimeOpen}
+              onItemClick={handleEditTimeClick}
+              setEditText={setEditTimeText}
+              setOpenEditDialog={setOpenTimeDialog}
+              setSelectedInfo={setSelectedTimeInfo}
+              cardColor="#e3f2fd"
+              getCountLabel={(count) => `${count}회`}
+            />
             
-            <Dialog open={openTimeDialog} onClose={() => setOpenTimeDialog(false)}>
-              <DialogTitle>시간 수정 / 삭제</DialogTitle>
-              <DialogContent>
-                <TextField
-                  label="시간"
-                  value={editTimeText}
-                  onChange={(e) => setEditTimeText(e.target.value)}
-                  fullWidth
-                />
-              </DialogContent>
-              <DialogActions>
-                <Button
-                  color="error"
-                  onClick={async () => {
-                    if (!selectedTimeInfo) return;
-                    const { routeId, timeId } = selectedTimeInfo;
-                    await update(ref(realtimeDb, `routes/${routeId}/times`), {[timeId]: null,});
-                   
-                    const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-                    const updatedData = updatedSnapshot.val();
-                   
-                    setAllRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, times: updatedData.times } : route
-                      )
-                    );
-                    setFilteredRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, times: updatedData.times } : route
-                      )
-                    );
-                    setOpenTimeDialog(false);
-                  
-                  }}
-                >
-                  삭제
-                </Button>
-                <Button
-                  color="primary"
-                  onClick={async () => {
-                    if (!selectedTimeInfo) return;
-                    const { routeId, timeId } = selectedTimeInfo;
-                    await set(ref(realtimeDb, `routes/${routeId}/times/${timeId}`), editTimeText); 
-                    const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-                    const updatedData = updatedSnapshot.val();
-                   
-                    setAllRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, times: updatedData.times } : route
-                      )
-                    );
-                    setFilteredRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, times: updatedData.times } : route
-                      )
-                    );
-                    setOpenTimeDialog(false);                 
-                  }}
-                >
-                  수정
-                </Button>
-              </DialogActions>
-            </Dialog>
+
+            <TimeAddDialog
+              open={isTimeDialogOpen}
+              value={routeText}
+              onChange={(e) => setRouteText(e.target.value)}
+              onClose={() => setIsTimeDialogOpen(false)}
+              onSubmit={handleSubmitTime}
+            />
+            
+            <TimeEditDialog
+              open={openTimeDialog}
+              value={editTimeText}
+              onChange={(e) => setEditTimeText(e.target.value)}
+              onUpdate={handleUpdateTime}
+              onDelete={handleDeleteTime}
+              onClose={() => setOpenTimeDialog(false)}
+            />
 
           </Box>
         </TabPanel>
         <TabPanel value={tabIndex} index={2}>
           <Box sx={{ width: '100%', backgroundColor: '#fff', padding: 2 }}>
-            <TextField
-              label="노선으로 검색"
-              variant="outlined"
-              size="small"
+            <SearchBar
               value={searchKeyword}
               onChange={(e) => setSearchKeyword(e.target.value)}
-              sx={{ width: '500px', mb: 2 }}
+              placeholder="노선으로 검색"
             />
 
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell style={{ width: "40%" }}>노선명</TableCell>
-                  <TableCell style={{ width: "20%" }}>정류장 수</TableCell>
-                  <TableCell style={{ width: "20%" }}>정류장 추가</TableCell>
-                  <TableCell style={{ width: "20%" }}>정류장 목록</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {filteredRoutes.map((route) => (
-                  <React.Fragment key={route.uid}>
-                    <TableRow key={route.uid}>
-                      <TableCell>{route.name}</TableCell>
-                      <TableCell>
-                        {route.stops ? Object.keys(route.stops).length + '개' : '0개'}
-                      </TableCell>
-                      <TableCell>
-                        <IconButton onClick={(e) => handleStopOpen(e, route)}>
-                          <AccessTimeIcon />
-                        </IconButton>
-                      </TableCell>
-                      <TableCell>
-                        <IconButton onClick={() => handleToggleTimes(route.uid)}>
-                          {openRouteId === route.uid ? (
-                            <ExpandLessIcon />
-                          ) : (
-                            <ExpandMoreIcon />
-                          )}
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  {openRouteId === route.uid && (
-                    <TableRow>
-                      <TableCell colSpan={4}>
-                        <Typography sx={{ mb: 1 }}>🚌 정류장 목록</Typography>
-                        {route.stops ? (
-                          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                            {Object.entries(route.stops).map(([stopId, stopName]) => (
-                              <Box
-                                key={stopId}
-                                onClick={() => {
-                                  setSelectedStopInfo({ routeId: route.uid, stopId, value: stopName });
-                                  setEditStopText(stopName);
-                                  setOpenStopEditDialog(true);
-                                }}
-                                sx={{
-                                  cursor: 'pointer',
-                                  width: '19%',
-                                  backgroundColor: '#fce4ec',
-                                  padding: '8px',
-                                  borderRadius: '4px',
-                                  textAlign: 'center',
-                                  boxShadow: 1,
-                                }}
-                              >
-                                {stopName}
-                              </Box>
-                            ))}
-                          </Box>
-                        ) : (
-                          <Typography color="text.secondary">등록된 정류장이 없습니다</Typography>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </React.Fragment>
-                ))}
-              </TableBody>
-            </Table>
+            <TimeStopTable
+              filteredRoutes={filteredRoutes}
+              openRouteId={openRouteId}
+              setOpenRouteId={setOpenRouteId}
+              itemKey="stops"
+              itemLabel="정류장"
+              onAddClick={handleStopOpen}
+              onItemClick={handleEditStopClick}
+              setEditText={setEditStopText}
+              setOpenEditDialog={setOpenStopEditDialog}
+              setSelectedInfo={setSelectedStopInfo}
+              cardColor="#fce4ec"
+              getCountLabel={(count) => `${count}개`}
+            />
 
-            <Dialog open={isRouteOpen} onClose={handleCloseMemo}>
-              <DialogTitle>정류장 추가</DialogTitle>
-              <DialogContent>
-                <TextField
-                  label="정류장 입력"
-                  multiline
-                  fullWidth
-                  value={routeText}
-                  onChange={(e) => setRouteText(e.target.value)}
-                />
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={handleSubmitMemo} color="primary">확인</Button>
-                <Button onClick={handleCloseMemo} color="secondary">취소</Button>
-              </DialogActions>
-            </Dialog>
-            
-            <Dialog open={openStopEditDialog} onClose={() => setOpenStopEditDialog(false)}>
-              <DialogTitle>정류장 수정 / 삭제</DialogTitle>
-              <DialogContent>
-                <TextField
-                  label="정류장명"
-                  value={editStopText}
-                  onChange={(e) => setEditStopText(e.target.value)}
-                  fullWidth
-                />
-              </DialogContent>
-              <DialogActions>
-                <Button
-                  color="error"
-                  onClick={async () => {
-                    if (!selectedStopInfo) return;
-                    const { routeId, stopId } = selectedStopInfo;
-                    await update(ref(realtimeDb, `routes/${routeId}/stops`), { [stopId]: null });
+            <StopAddDialog
+              open={isStopDialogOpen}
+              value={routeText}
+              onChange={(e) => setRouteText(e.target.value)}
+              onSubmit={handleSubmitStop}
+              onClose={() => setIsStopDialogOpen(false)}
+            />
 
-                    const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-                    const updatedData = updatedSnapshot.val();
-
-                    setAllRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-                      )
-                    );
-                    setFilteredRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-                      )
-                    );
-
-                    setOpenStopEditDialog(false);
-                  }}
-                >
-                  삭제
-                </Button>
-                <Button
-                  color="primary"
-                  onClick={async () => {
-                    if (!selectedStopInfo) return;
-                    const { routeId, stopId } = selectedStopInfo;
-                    await set(ref(realtimeDb, `routes/${routeId}/stops/${stopId}`), editStopText);
-
-                    const updatedSnapshot = await get(ref(realtimeDb, `routes/${routeId}`));
-                    const updatedData = updatedSnapshot.val();
-
-                    setAllRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-                      )
-                    );
-                    setFilteredRoutes((prev) =>
-                      prev.map((route) =>
-                        route.uid === routeId ? { ...route, stops: updatedData.stops } : route
-                      )
-                    );
-
-                    setOpenStopEditDialog(false);
-                  }}
-                >
-                  수정
-                </Button>
-              </DialogActions>
-            </Dialog>
-
+            <StopEditDialog
+              open={openStopEditDialog}
+              value={editStopText}
+              onChange={(e) => setEditStopText(e.target.value)}
+              onUpdate={handleUpdateStop}
+              onDelete={handleDeleteStop}
+              onClose={() => setOpenStopEditDialog(false)}
+            />
 
           </Box>
         </TabPanel>

--- a/refacbus_admin/src/pages/ReservationManagement.jsx
+++ b/refacbus_admin/src/pages/ReservationManagement.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { TextField, Box, Button, } from '@mui/material';
+import { Typography, Box, Button, } from '@mui/material';
 import { getDatabase, ref, get, child } from 'firebase/database';
 import TabbedContainer from '../components/common/TabbedContainer';
 import TabPanel from '../components/common/TabPanel';
@@ -9,13 +9,17 @@ import StatFilterBar from '../components/Reservation/StatFilterBar';
 import DeleteStatFilterBar from '../components/Reservation/DeleteStatFilterBar';
 import StatBarChart from '../components/Reservation/StatBarChart';
 import SearchBar from '../components/common/SearchBar';
+import { useAdmin } from '../context/AdminContext';
+import { hasPermission } from '../utils/permissionUtil';
 
 
 const ReservationManagement = () => {
+  const admin = useAdmin();
+    if (!admin) return null;
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabChange = (event, newValue) => setTabIndex(newValue);
 
-  // -------------------- 🔹 [2] 날짜별 예약자 목록 --------------------
+  //날짜별 예약자 목록
   const [year, setYear] = useState('');
   const [month, setMonth] = useState('');
   const [day, setDay] = useState('');
@@ -78,7 +82,7 @@ const ReservationManagement = () => {
     }
   };
 
-  // -------------------- 🔹 [3] 예약 통계 --------------------
+  //예약 통계
   const [statType, setStatType] = useState('routeTotal');
   const [filterValue, setFilterValue] = useState('');
   const [chartYear, setChartYear] = useState('');
@@ -160,7 +164,7 @@ const ReservationManagement = () => {
     fetchRouteNames();
   }, []);
 
-  // -------------------- 🔹 [4] 예약 취소 통계 --------------------
+  //예약 취소 통계 
   const [allDeletedReservations, setAllDeletedReservations] = useState([]);
   const [deleteType, setDeleteType] = useState("routeTotal");
   const [filteredRouteDeletes, setFilteredRouteDeletes] = useState([]);
@@ -279,45 +283,56 @@ const ReservationManagement = () => {
           maxWidth: 'none',
         }}
       >
-        <TabPanel value={tabIndex} index={0}> 
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2,}}>
-            <DateSelector
-              year={year}
-              month={month}
-              day={day}
-              onYearChange={handleYearChange}
-              onMonthChange={handleMonthChange}
-              onDayChange={handleDayChange}
-              allowEmpty={false} 
-            />
+        <TabPanel value={tabIndex} index={0}>
+          {hasPermission(admin, '예약자 목록') ? ( 
+          <Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2,}}>
+              <DateSelector
+                year={year}
+                month={month}
+                day={day}
+                onYearChange={handleYearChange}
+                onMonthChange={handleMonthChange}
+                onDayChange={handleDayChange}
+                allowEmpty={false} 
+              />
 
-            <SearchBar
-              value={searchKeyword}
-              onChange={(e) => setSearchKeyword(e.target.value)}
-              placeholder="이름으로 검색"
-            />
+             <SearchBar
+                value={searchKeyword}
+                onChange={(e) => setSearchKeyword(e.target.value)}
+                placeholder="이름으로 검색"
+              />
               
-            <Button variant="contained" onClick={handleSearch}>조회</Button>
-          </Box>
-          <ReservationListTable data={filteredData} />
-
+              <Button variant="contained" onClick={handleSearch}>조회</Button>
+            </Box>
+            <ReservationListTable data={filteredData} />
+          </Box> 
+           ) : (
+          <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+        )}  
         </TabPanel>
         <TabPanel value={tabIndex} index={1}>
-          <StatFilterBar
-            statType={statType}
-            onTypeChange={handleStatTypeChange}
-            chartYear={chartYear}
-            chartMonth={chartMonth}
-            chartDay={chartDay}
-            onYearChange={handleChartYearChange}
-            onMonthChange={handleChartMonthChange}
-            onDayChange={handleChartDayChange}
-            selectedRoute={selectedRoute}
-            onRouteChange={setSelectedRoute}
-            routeList={routeList}
-            onSearchClick={handleChartSearch}
-          />
-          <StatBarChart data={filteredRouteStats} />
+          {hasPermission(admin, '예약 통계') ? (
+          <Box>
+            <StatFilterBar
+              statType={statType}
+              onTypeChange={handleStatTypeChange}
+              chartYear={chartYear}
+              chartMonth={chartMonth}
+              chartDay={chartDay}
+              onYearChange={handleChartYearChange}
+              onMonthChange={handleChartMonthChange}
+              onDayChange={handleChartDayChange}
+              selectedRoute={selectedRoute}
+              onRouteChange={setSelectedRoute}
+              routeList={routeList}
+              onSearchClick={handleChartSearch}
+            />
+            <StatBarChart data={filteredRouteStats} />
+          </Box>
+          ) : (
+          <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+        )}
         </TabPanel>
         <TabPanel value={tabIndex} index={2}>
           <DeleteStatFilterBar

--- a/refacbus_admin/src/pages/UserManagement.jsx
+++ b/refacbus_admin/src/pages/UserManagement.jsx
@@ -1,9 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import {
-  TextField, Box, Table, TableHead, TableCell, TableRow, TableBody,
-  Menu, MenuItem, Dialog, DialogTitle, DialogContent, DialogActions,
-  Checkbox, FormControlLabel, Button, Typography, Paper
-} from '@mui/material';
+import {  Box, Typography } from '@mui/material';
 import { ref, get, update, push, set } from "firebase/database";
 import { realtimeDb, auth } from "../firebase";
 import { sendPasswordResetEmail } from "firebase/auth";
@@ -14,10 +10,14 @@ import MemoHistoryDialog from '../components/User/MemoHistoryDialog';
 import UserEditDialog from '../components/User/UserEditDialog';
 import PasswordResetDialog from '../components/User/PasswordResetDialog';
 import SearchBar from '../components/common/SearchBar';
+import { useAdmin } from '../context/AdminContext';
+import { hasPermission } from '../utils/permissionUtil';
 
 
 
 const UserManagement = () => {
+  const admin = useAdmin();
+    if (!admin) return null;
   //검색 및 사용자 목록 상태
   const [searchKeyword, setSearchKeyword] = useState('');
   const [filteredUsers, setFilteredUsers] = useState([]);
@@ -206,6 +206,7 @@ const UserManagement = () => {
   };
 
   return (
+    hasPermission(admin, '회원 관리') ? (
     <Box sx={{ width: '100%', backgroundColor: '#fff', padding: 2 }}>
       <SearchBar
         value={searchKeyword}
@@ -275,6 +276,9 @@ const UserManagement = () => {
         onClose={() => setIsResetOpen(false)}
       />
     </Box>
+    ) : (
+    <Typography color="error">이 기능에 대한 권한이 없습니다.</Typography>
+  )
   );
 };
 

--- a/refacbus_admin/src/pages/UserManagement.jsx
+++ b/refacbus_admin/src/pages/UserManagement.jsx
@@ -18,29 +18,39 @@ import SearchBar from '../components/common/SearchBar';
 
 
 const UserManagement = () => {
+  //검색 및 사용자 목록 상태
   const [searchKeyword, setSearchKeyword] = useState('');
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [allUsers, setAllUsers] = useState([]);
 
+  //context 메뉴 상태
   const [anchorEl, setAnchorEl] = useState(null);
   const [anchorUserId, setAnchorUserId] = useState(null);
 
+  //메모 다이얼로그
   const [isMemoOpen, setIsMemoOpen] = useState(false);
   const [selectedUserForMemo, setSelectedUserForMemo] = useState(null);
   const [memoText, setMemoText] = useState("");
   const [isWarning, setIsWarning] = useState(false);
   const [isBan, setIsBan] = useState(false);
+
+  //메모 기록 확인
   const [isMemoHistoryOpen, setIsMemoHistoryOpen] = useState(false);
   const [selectedMemoList, setSelectedMemoList] = useState([]);
   const [memoFilter, setMemoFilter] = useState("all");
+
+  //사용자 정보 수정
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [editingUser, setEditingUser] = useState(null);
   const [editedEmail, setEditedEmail] = useState("");
   const [editedName, setEditedName] = useState("");
+
+  //비밀번호 초기화
   const [resetEmail, setResetEmail] = useState('');
   const [isResetOpen, setIsResetOpen] = useState(false);
   const [targetUser, setTargetUser] = useState(null);
 
+  //사용자 불러오기
   useEffect(() => {
     const fetchUsers = async () => {
       const snapshot = await get(ref(realtimeDb, "users"));
@@ -62,6 +72,8 @@ const UserManagement = () => {
     setFilteredUsers(filtered);
   }, [searchKeyword, allUsers]);
 
+
+  //context 메뉴 관련
   const handleMenuOpen = (event, user) => {
     setAnchorEl(event.currentTarget);
     setAnchorUserId(user.uid);
@@ -72,6 +84,7 @@ const UserManagement = () => {
     setAnchorUserId(null);
   };
 
+  //메모 다이얼로그
   const handleOpenMemo = (user) => {
     setSelectedUserForMemo(user);
     setIsMemoOpen(true);
@@ -133,7 +146,7 @@ const UserManagement = () => {
   };
 
 
-    const handleUnban = async (uid) => {
+  const handleUnban = async (uid) => {
     await update(ref(realtimeDb, `users/${uid}`), { isBanned: false });
 
     setAllUsers((prev) =>
@@ -146,6 +159,8 @@ const UserManagement = () => {
     handleMenuClose();
   };
 
+
+  //메모 히스토리 관련
   const handleOpenMemoHistory = async (user) => {
     const memoRef = ref(realtimeDb, `users/${user.uid}/memo`);
     const snapshot = await get(memoRef);
@@ -165,7 +180,7 @@ const UserManagement = () => {
     setIsMemoHistoryOpen(true);
   };
 
-
+  //사용자 정보 수정 관련
   const handleOpenEditDialog = (user) => {
     setEditingUser(user);
     setEditedEmail(user.email ?? "");
@@ -173,6 +188,7 @@ const UserManagement = () => {
     setIsEditDialogOpen(true);
   };
 
+  //비밀번호 초기화 관련
   const handleOpenReset = (user) => {
     setTargetUser(user);
     setResetEmail(user.email); 

--- a/refacbus_admin/src/utils/permissionUtil.js
+++ b/refacbus_admin/src/utils/permissionUtil.js
@@ -1,0 +1,4 @@
+// src/utils/permissionUtils.js
+export const hasPermission = (admin, key) => {
+  return admin?.name === '박정원' || admin?.permissions?.[key];
+};


### PR DESCRIPTION
## 설명  
관리자 계정별 권한을 설정하고, 설정된 권한에 따라 기능 접근을 제한하는 기능을 구현했습니다.  
슈퍼 계정("박정원")은 항상 모든 권한을 자동 부여받습니다.

---

##  구현 내용 요약  
- `RoleDialog`를 통한 관리자 권한 설정 다이얼로그 구현  
  - 대분류 기능 클릭 시 하위 기능 일괄 체크  
  - 개별 하위 기능 선택도 가능  
- 권한 데이터 Firebase Realtime Database(`admin/uid/permissions`)에 저장  
- `useAdmin()` + `hasPermission()` 기반 기능 접근 제어  
  - 관리자 계정이 없는 기능 접근 시 “권한이 없습니다” 메시지 표시  
- `ALL_PERMISSIONS` 상수 분리 → `permissions.js`로 모듈화  

---

## 관련 변경사항  
- `ManagerManagement.jsx` 리팩토링  
  - 권한에 따라 탭 표시 및 내부 콘텐츠 조건 렌더링 적용  
- `AdminContext.jsx` 생성 → `AdminProvider`로 로그인 관리자 권한 제공  
- `permissionUtil.js` 생성 → `hasPermission()` 함수 작성  
- `RoleDialog.jsx` 추가 → 관리자 권한 설정 UI  
- `main.jsx`에서 `<AdminProvider>`로 앱 전체 감싸도록 구조 변경  
- `UserTable.jsx`에서 권한 설정 버튼 연결 (`onRoleClick`)  
- `permissions.js` 생성 → 모든 기능에 대한 권한 목록 상수화  

---

## 참고사항  
- 슈퍼 계정("박정원")은 자동으로 `ALL_PERMISSIONS`이 DB에 저장되며, 수정 불가  / 권한 설정 불가
- 향후 로그 기능이나 권한 변경 이력 저장 시 `memo`처럼 push 구조 확장 가능  

---

## 테스트 방법  
- [x] 슈퍼계정 (박정원)의 권한 설정 불가 확인
- [x] 관리자 계정으로 로그인 후 관리자 목록 확인  
- [x] 다른 관리자 계정의 `...` → "권한 설정" 클릭 시 다이얼로그 정상 출력  
- [x] 대분류 클릭 시 하위 항목 일괄 체크 확인  
- [x] 저장 후 DB에 `permissions` 필드 정상 저장 확인  
- [x] 다른 관리자 계정으로 로그인 시 권한에 따라 기능 접근 여부 제한 확인  
- [x] 권한이 없는 기능 탭 숨김 및 진입 시 “권한이 없습니다” 문구 노출 확인  

close #19 
