### PR TITLE
전체 수정 및 테스트 후 개선

### DIFF
--- a/refacbus_admin/src/components/calendar/SharedCalendar.jsx
+++ b/refacbus_admin/src/components/calendar/SharedCalendar.jsx
@@ -2,24 +2,17 @@
 import React from "react";
 import Calendar from "react-calendar";
 import Paper from "@mui/material/Paper";
-import "./SharedCalendar.css"; 
+import "./SharedCalendar.css";
+import dayjs from "dayjs";
 
-
-const SharedCalendar = ({ value, onChange, markedDates = [] }) => {
+const SharedCalendar = ({ value, onChange, markedDates = [], onMonthChange }) => {
   const tileClassName = ({ date, view }) => {
     if (view === "month") {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, "0");
-      const day = String(date.getDate()).padStart(2, "0");
-      const dateStr = `${year}-${month}-${day}`;
-
-      if (markedDates.includes(dateStr)) {
-        return "highlight";
-      }
+      const formatted = dayjs(date).format("YYYY-MM-DD");
+      return markedDates.includes(formatted) ? "highlight" : null;
     }
     return null;
   };
-
 
   return (
     <Paper
@@ -41,6 +34,12 @@ const SharedCalendar = ({ value, onChange, markedDates = [] }) => {
         value={value}
         className="custom-calendar"
         tileClassName={tileClassName}
+        onActiveStartDateChange={({ activeStartDate }) => {
+          const newMonth = activeStartDate.getMonth() + 1;
+          const newYear = activeStartDate.getFullYear();
+          const newMonthStr = `${newYear}-${String(newMonth).padStart(2, '0')}`;
+          onMonthChange?.(newMonthStr); // 부모에서 이걸 받아서 setValue에 반영
+        }}
       />
     </Paper>
   );

--- a/refacbus_admin/src/pages/DashBoard.jsx
+++ b/refacbus_admin/src/pages/DashBoard.jsx
@@ -1,18 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import Box from '@mui/material/Box';
-import Calendar from 'react-calendar';
-import 'react-calendar/dist/Calendar.css';
-import { Typography, List, ListItemButton, ListItemText, Paper } from '@mui/material';
-import { getDatabase, ref, onValue, get } from 'firebase/database';
+import React, { useEffect, useState } from "react";
 import SharedCalendar from "../components/calendar/SharedCalendar";
-import ScheduleCardBox from "../components/DashBoardSchedule/ScheduleCardBox"; 
+import { get, ref, getDatabase, onValue } from "firebase/database";
+import { realtimeDb } from "../firebase";
+import { Box, Typography, List, ListItem, ListItemText, Paper } from "@mui/material";
+import dayjs from "dayjs";
 import NoticeList from '../components/Notice/NoticeList';
 
 const Dashboard = () => {
-  const [value, setValue] = useState(new Date());
+  const [value, setValue] = useState(new Date()); 
+  const [markedDates, setMarkedDates] = useState([]); 
+  const [scheduleList, setScheduleList] = useState([]);
+  const [currentMonth, setCurrentMonth] = useState(dayjs().format("YYYY-MM"));
   const [notices, setNotices] = useState([]);
-  const [markedDates, setMarkedDates] = useState([]);
-
 
   useEffect(() => {
     const db = getDatabase();
@@ -28,52 +27,94 @@ const Dashboard = () => {
   }, []);
 
   useEffect(() => {
-    const fetchMarkedDates = async () => {
-          const db = getDatabase();
-          const scheduleRef = ref(db, "managerSchedules");
-          const snapshot = await get(scheduleRef);
-    
-          if (snapshot.exists()) {
-            const data = snapshot.val();
-    
-            const uniqueDates = new Set();
-            for (const date of Object.keys(data)) {
-              const entries = Object.values(data[date]);
-              if (entries.length > 0) {
-                uniqueDates.add(date);
-              }
-            }
-    
-            setMarkedDates(Array.from(uniqueDates));
-          }
-        };
-    
-        fetchMarkedDates();
-      
-  }, []);
-    
+  const fetchSchedulesForMonth = async () => {
+    if (!currentMonth) return;
+
+    const db = getDatabase();
+    const monthRef = ref(db, `managerSchedules/${currentMonth}`);
+    const snapshot = await get(monthRef);
+
+    if (!snapshot.exists()) {
+      console.log("❌ 해당 월의 일정 없음");
+      setScheduleList([]);
+      return;
+    }
+
+    const data = snapshot.val();
+    console.log("📦 가져온 managerSchedules 데이터:", data);
+
+    const scheduleArray = [];
+
+    for (const dayKey in data) {
+      const item = data[dayKey];
+      if (item?.text) {
+        scheduleArray.push({
+          date: dayKey,
+          text: item.text,
+          createdAt: item.createdAt,
+        });
+      }
+    }
+
+    console.log("✅ 추출한 일정 배열:", scheduleArray);
+    setScheduleList(scheduleArray);
+    setMarkedDates(scheduleArray.map(s => s.date));
+  };
+
+  fetchSchedulesForMonth();
+}, [currentMonth]);
+
+
+  const handleMonthChange = (newMonthStr) => {
+    setValue(dayjs(newMonthStr + "-01").toDate());
+    setCurrentMonth(newMonthStr); 
+  };
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Typography variant="h5" gutterBottom>
-        관리자 대시보드
-      </Typography>
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      
+      {/* 공지사항 위쪽 배치 */}
+      <NoticeList notices={notices} />
 
-      <Box sx={{ display: 'flex', gap: 2}}>
+      {/* 캘린더 + 일정 목록을 가로로 붙이기 */}
+      <Box sx={{ display: "flex", height: 400, boxShadow: 3 }}>
         {/* 캘린더 */}
-        <SharedCalendar
-          value={value}
-          onChange={setValue}
-          markedDates={markedDates}
-        />
+        <Box sx={{ borderRight: "1px solid #ccc", p: 2 }}>
+          <SharedCalendar
+            value={value}
+            onChange={setValue}
+            markedDates={markedDates}
+            onMonthChange={handleMonthChange}
+          />
+        </Box>
 
-        {/* 공지사항 */}
-        <NoticeList notices={notices} />
+        {/* 일정 목록 */}
+        <Box sx={{ width: 500, p: 2, overflowY: "auto" }}>
+          <Typography variant="h6" gutterBottom>
+            📅 {dayjs(value).format("YYYY년 MM월")} 일정 목록
+          </Typography>
+          {scheduleList.length === 0 ? (
+            <Typography variant="body2" sx={{ mt: 2 }}>
+              해당 월의 일정이 없습니다.
+            </Typography>
+          ) : (
+            <List>
+              {scheduleList
+                .filter((s) => s.date.startsWith(currentMonth))
+                .map((s, i) => (
+                  <Box key={i} sx={{ mb: 1 }}>
+                    <strong>{s.date}</strong>
+                    <br />
+                    {s.text}
+                  </Box>
+              ))}
+            </List>
+          )}
+        </Box>
       </Box>
-      <ScheduleCardBox />
     </Box>
   );
-};
 
+};
 
 export default Dashboard;


### PR DESCRIPTION
### 설명

관리자 대시보드에 월별 일정을 조회하고, 캘린더에 표시되는 기능을 구현했습니다.  
또한 공지사항과 일정 목록을 나란히 배치하고, 일정 목록은 캘린더 아래에 붙도록 레이아웃을 개선했습니다.

---

### 구현 내용 요약

- `Dashboard.jsx`
  - Realtime Database에서 `managerSchedules/{YYYY-MM}` 경로로 데이터 가져오기
  - 일정이 있는 날짜를 추출하여 `markedDates` 배열로 관리
  - 해당 월에 포함된 일정만 필터링하여 일정 리스트로 출력
  - 공지사항과 일정 목록이 캘린더 기준으로 잘 정렬되도록 레이아웃 구성 수정
  - `onMonthChange` 핸들러에서 `currentMonth` 상태 갱신

- `SharedCalendar.jsx`
  - `tileClassName`에서 일정이 있는 날짜(`markedDates`) 하이라이팅
  - `onActiveStartDateChange`에서 월이 바뀌면 `onMonthChange` 콜백 호출

---

### 관련 변경사항

- `Dashboard.jsx` 전체 레이아웃을 수직 + 수평 조합 구조로 변경 -> 다시 구조 변경 예정
- Firebase에서 일정 데이터 읽어오고 추출하는 로직 추가
- 일정 데이터 구조에 맞게 날짜별 일정 텍스트 출력

---

### 테스트 방법

- [x] 관리자 대시보드 접속 시 해당 월의 일정이 오른쪽 목록에 출력되는지 확인
- [x] 일정이 있는 날짜가 파란색으로 하이라이팅되는지 확인
- [x] 월을 넘겼을 때 일정 목록과 하이라이팅이 새로운 월 데이터로 갱신되는지 확인
- [x] 일정이 없는 달에는 "해당 월의 일정이 없습니다." 문구가 나오는지 확인
- [x] 공지사항이 캘린더 오른쪽에 잘 정렬되어 있는지 확인
