### PR TITLE
UX/UI 개선

### DIFF
--- a/refacbus_admin/src/components/Sidebar.jsx
+++ b/refacbus_admin/src/components/Sidebar.jsx
@@ -24,7 +24,7 @@ import VerifiedUser from '@mui/icons-material/PersonOutline';
 
 const drawerWidth = 240;
 
-const Sidebar = ({ onMenuSelect }) => {
+const Sidebar = ({ onMenuSelect, selectedMenu }) => {
 
   const navigate = useNavigate();
 
@@ -37,6 +37,13 @@ const Sidebar = ({ onMenuSelect }) => {
       alert("로그아웃에 실패했습니다.");
     }
   };
+  
+  const menuButtonStyle = (isSelected) => ({
+    backgroundColor: isSelected ? '#0059b3 !important' : 'transparent',
+    '&:hover': {
+      backgroundColor: '#0073e6',
+    },
+  });
 
   const [adminName, setAdminName] = useState('');
 
@@ -83,26 +90,46 @@ const Sidebar = ({ onMenuSelect }) => {
       </Toolbar>
       <Divider sx={{ backgroundColor: '#ffffff33' }} />
       <List>
-        <ListItemButton  onClick={() => onMenuSelect('user')}>
+        <ListItemButton 
+          selected={selectedMenu === 'user'}
+          onClick={() => onMenuSelect('user')}
+          sx={menuButtonStyle(selectedMenu === 'user')}>
           <ListItemIcon sx={{ color: 'white' }}><PlaceTimeIcon /></ListItemIcon>
           <ListItemText primary="회원 관리" />
         </ListItemButton>
-        <ListItemButton onClick={() => onMenuSelect('placetime')}>
+
+        <ListItemButton 
+          selected={selectedMenu === 'placetime'}
+          onClick={() => onMenuSelect('placetime')}
+          sx={menuButtonStyle(selectedMenu === 'placetime')}>
           <ListItemIcon sx={{ color: 'white' }}><UserIcon /></ListItemIcon>
           <ListItemText primary="노선/시간 관리" />
         </ListItemButton>
-        <ListItemButton onClick={() => onMenuSelect('reservation')}>
+
+        <ListItemButton 
+          selected={selectedMenu === 'reservation'}
+          onClick={() => onMenuSelect('reservation')}
+          sx={menuButtonStyle(selectedMenu === 'reservation')}>
           <ListItemIcon sx={{ color: 'white' }}><ReservationsIcon /></ListItemIcon>
           <ListItemText primary="예약 현황/통계" />
         </ListItemButton>
-        <ListItemButton onClick={() => onMenuSelect('drivenote')}>
+
+        <ListItemButton 
+          selected={selectedMenu === 'drivenote'}
+          onClick={() => onMenuSelect('drivenote')}
+          sx={menuButtonStyle(selectedMenu === 'drivenote')}>
           <ListItemIcon sx={{ color: 'white' }}><DriveNoteIcon /></ListItemIcon>
           <ListItemText primary="운행 기록 확인" />
         </ListItemButton>
-        <ListItemButton onClick={() => onMenuSelect('managermanage')}>
+
+        <ListItemButton 
+          selected={selectedMenu === 'managermanage'}
+          onClick={() => onMenuSelect('managermanage')}
+          sx={menuButtonStyle(selectedMenu === 'managermanage')}>
           <ListItemIcon sx={{ color: 'white' }}><ManagerIcon /></ListItemIcon>
           <ListItemText primary="관리자 계정 관리" />
         </ListItemButton>
+
       </List>
       <Divider sx={{ backgroundColor: '#ffffff33' }} />
       <List>

--- a/refacbus_admin/src/pages/DashBoard.jsx
+++ b/refacbus_admin/src/pages/DashBoard.jsx
@@ -71,49 +71,55 @@ const Dashboard = () => {
   };
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+    <Box sx={{ display: "flex", gap: 3 }}>
       
-      {/* 공지사항 위쪽 배치 */}
-      <NoticeList notices={notices} />
+      {/* 왼쪽: 캘린더 + 일정목록 세로 배치 */}
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <SharedCalendar
+          value={value}
+          onChange={setValue}
+          markedDates={markedDates}
+          onMonthChange={handleMonthChange}
+        />
 
-      {/* 캘린더 + 일정 목록을 가로로 붙이기 */}
-      <Box sx={{ display: "flex", height: 400, boxShadow: 3 }}>
-        {/* 캘린더 */}
-        <Box sx={{ borderRight: "1px solid #ccc", p: 2 }}>
-          <SharedCalendar
-            value={value}
-            onChange={setValue}
-            markedDates={markedDates}
-            onMonthChange={handleMonthChange}
-          />
-        </Box>
-
-        {/* 일정 목록 */}
-        <Box sx={{ width: 500, p: 2, overflowY: "auto" }}>
+        <Paper sx={{ width: 500, height: 400, p: 2, borderRadius: 2, overflowY: "auto" }}>
           <Typography variant="h6" gutterBottom>
             📅 {dayjs(value).format("YYYY년 MM월")} 일정 목록
           </Typography>
+
           {scheduleList.length === 0 ? (
             <Typography variant="body2" sx={{ mt: 2 }}>
               해당 월의 일정이 없습니다.
             </Typography>
           ) : (
-            <List>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr", // ✅ 2단 구조
+                gap: 2,
+              }}
+            >
               {scheduleList
                 .filter((s) => s.date.startsWith(currentMonth))
                 .map((s, i) => (
-                  <Box key={i} sx={{ mb: 1 }}>
-                    <strong>{s.date}</strong>
-                    <br />
-                    {s.text}
+                  <Box key={i}>
+                    <Typography variant="subtitle2" fontWeight="bold">
+                      {s.date}
+                    </Typography>
+                    <Typography variant="body2">{s.text}</Typography>
                   </Box>
-              ))}
-            </List>
+                ))}
+            </Box>
           )}
-        </Box>
+        </Paper>
+
       </Box>
+
+      {/* 오른쪽: 공지사항 */}
+      <NoticeList notices={notices} />
     </Box>
   );
+
 
 };
 

--- a/refacbus_admin/src/pages/Home.jsx
+++ b/refacbus_admin/src/pages/Home.jsx
@@ -51,7 +51,8 @@ function Home() {
 
       {/* ✅ 사이드바 (고정된 폭) */}
       <Box sx={{ width: 200 }}>
-        <Sidebar onMenuSelect={setSelectedMenu} />
+        <Sidebar onMenuSelect={setSelectedMenu} selectedMenu={selectedMenu} />
+
       </Box>
 
       {/* ✅ 메인 컨텐츠 영역 (나머지 전부 차지) */}


### PR DESCRIPTION
## PR 제목: 대시보드 UI 정렬 및 사이드바 선택 상태 개선

### 설명
- 대시보드 화면 내 구성요소의 레이아웃을 개선하고, 관리자 경험을 향상시키기 위해 사이드바 탭 선택 상태 스타일을 적용했습니다.

---

### 구현 내용 요약
1. **대시보드 레이아웃 재정비**
   - 캘린더 + 일정 목록 → 수직 정렬 (한 줄 세로 배치)
   - 일정 목록 오른쪽에 공지사항 배치

2. **일정 목록 UI 2단 구성**
   - 일정 목록을 단일 열에서 2열로 분할 (`display: grid`, `gridTemplateColumns` 사용)
   - 더 많은 일정을 깔끔하게 시각화 가능

3. **사이드바 선택 탭 강조**
   - 현재 선택된 탭에 대해 색상 유지 (`selectedMenu` prop 기반)
   - 커서 hover 외에도 클릭 후 배경색 유지 처리
   - 메뉴 선택 시 색상 업데이트 (`backgroundColor` 동적 적용)

---

###  관련 변경 파일
- `Dashboard.jsx`
- `Sidebar.jsx`
- `Home.jsx`
- `SharedCalendar.jsx`

---

### 🧪 테스트 방법
- [x] 사이드바에서 메뉴 클릭 시, 해당 탭 색상이 유지되는지 확인
- [x] 대시보드 캘린더 아래 일정 목록이 2열로 나오는지 확인
- [x] 일정이 존재하는 경우 달력에 하이라이트 및 일정 목록에 정상 출력되는지 확인
- [x] 공지사항이 일정 목록 오른쪽에 제대로 붙어있는지 확인
